### PR TITLE
Alias

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,12 @@ Authors@R: c(
 		"Ben-Shachar",
 		role = c("aut"),
 		email = "matanshm@post.bgu.ac.il",
-		comment = c(ORCID = "0000-0002-4287-4801"))
+		comment = c(ORCID = "0000-0002-4287-4801")),
+	person("Brenton M.", 
+		"Wiernik", 
+		email = "brenton@wiernik.org",
+		role = c("ctb"), 
+		comment = c(ORCID = "/0000-0001-9560-6336"))
 	)
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 URL: https://easystats.github.io/see/

--- a/R/geom_point2.R
+++ b/R/geom_point2.R
@@ -5,7 +5,7 @@
 #' @param size Size of points.
 #' @param stroke Stroke thickness.
 #' @param shape Shape of points.
-#' @param ... Other arguments to be passed to \code{\link[ggplot2::geom_point]{ggplot2::geom_point}} or \code{\link[ggplot2::geom_jitter]{ggplot2::geom_jitter}}.
+#' @param ... Other arguments to be passed to \code{\link[ggplot2::geom_point]{ggplot2::geom_point}}, \code{\link[ggplot2::geom_jitter]{ggplot2::geom_jitter}}, \code{\link[ggplot2::geom_pointrange]{ggplot2::geom_pointrange}}, or \code{\link[ggplot2::geom_count]{ggplot2::geom_count}}.
 #'
 #' @examples
 #' library(ggplot2)
@@ -40,3 +40,25 @@ geom_jitter2 <- function(..., size = 2, stroke = 0, shape = 16){
 #' @rdname geom_point2
 #' @export
 geom_jitter_borderless <- geom_jitter2
+
+
+#' @rdname geom_point2
+#' @export
+geom_pointrange2 <- function(..., stroke = 0){
+  geom_pointrange(stroke = stroke, ...)
+}
+
+#' @rdname geom_point2
+#' @export
+geom_pointrange_borderless <- geom_pointrange2
+
+
+#' @rdname geom_point2
+#' @export
+geom_count2 <- function(..., stroke = 0){
+  geom_count(stroke = stroke, ...)
+}
+
+#' @rdname geom_point2
+#' @export
+geom_count_borderless <- geom_count2

--- a/R/geom_point2.R
+++ b/R/geom_point2.R
@@ -1,11 +1,11 @@
 #' Better looking points
 #'
-#' Somewhat nicer points (especially in case of transparency) without borders and contour.
+#' Somewhat nicer points (especially in case of transparency) without outline strokes (borders, contours) by default.
 #'
 #' @param size Size of points.
 #' @param stroke Stroke thickness.
 #' @param shape Shape of points.
-#' @param ... Other arguments to be passed to \code{geom_point}.
+#' @param ... Other arguments to be passed to \code{\link[ggplot2::geom_point]{ggplot2::geom_point}} or \code{\link[ggplot2::geom_jitter]{ggplot2::geom_jitter}}.
 #'
 #' @examples
 #' library(ggplot2)
@@ -26,6 +26,9 @@ geom_point2 <- function(..., stroke = 0, shape = 16) {
   geom_point(stroke = stroke, shape = shape, ...)
 }
 
+#' @rdname geom_point2
+#' @export
+geom_point_borderless <- geom_point2
 
 
 #' @rdname geom_point2
@@ -33,3 +36,7 @@ geom_point2 <- function(..., stroke = 0, shape = 16) {
 geom_jitter2 <- function(..., size = 2, stroke = 0, shape = 16){
   geom_jitter(size = size, stroke = stroke, shape = shape, ...)
 }
+
+#' @rdname geom_point2
+#' @export
+geom_jitter_borderless <- geom_jitter2


### PR DESCRIPTION
Adds `geom_point_borderless` as an alias for `geom_point_2` and the analgous alias for jitter. Also adds borderless versions of `geom_pointrange` and `geom_count` to round out the four point-having geoms in ggplot2.

Closes #75.