### PR TITLE
Add ellipsis to geom_violinhalf inside geom_violindot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,12 @@ Authors@R: c(
 		"Wiernik", 
 		email = "brenton@wiernik.org",
 		role = c("ctb"), 
-		comment = c(ORCID = "0000-0001-9560-6336"))
+		comment = c(ORCID = "0000-0001-9560-6336")),
+	person("Jeffrey R.", 
+		"Stevens", 
+		email = "jeffrey.r.stevens@gmail.com",
+		role = c("ctb"), 
+		comment = c(ORCID = "0000-0003-2375-1360"))
 	)
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 URL: https://easystats.github.io/see/

--- a/R/geom_violindot.R
+++ b/R/geom_violindot.R
@@ -81,14 +81,15 @@ geom_violindot <- function(mapping = NULL, data = NULL, trim = TRUE, scale = "ar
 
   list(
     geom_violinhalf(mapping=mapping,
-                   data=data,
-                   stat="ydensity",
-                   position="dodge",
-                   trim=trim,
-                   scale=scale,
-                   show.legend=show.legend,
-                   inherit.aes=inherit.aes),
+                    data=data,
+                    stat="ydensity",
+                    position="dodge",
+                    trim=trim,
+                    scale=scale,
+                    show.legend=show.legend,
+                    inherit.aes=inherit.aes,
+                    ...),
     dotplot
-    )
+  )
 
 }


### PR DESCRIPTION
**Problem:** Currently, the alpha argument in the `geom_violindot()` function only applies to the dots and not the violin. This is because, within `geom_violindot`, the ellipsis argument is passed only to `geom_dotplot` but not to `geom_violinhalf`.
**Solution:** Adding the ellipsis argument to the call to `geom_violinhalf` within `geom_violindot` allows the alpha argument to pass to the violin so users can control transparency of the violin fill.