### PR TITLE
Fixed violin attributes

### DIFF
--- a/R/geom_violindot.R
+++ b/R/geom_violindot.R
@@ -20,8 +20,9 @@
 #' @import ggplot2
 #' @export
 geom_violindot <- function(mapping = NULL, data = NULL, trim = TRUE, scale = "area",
-                           show.legend = NA, inherit.aes = TRUE, size_dots = 0.7, color_dots=NULL,
-                           binwidth=0.05, position_dots = ggplot2::position_nudge(x = -0.025, y = 0), ..., fill_dots=NULL) {
+                           show.legend = NA, inherit.aes = TRUE, size_dots = 0.7,
+                           binwidth = 0.05, position_dots = ggplot2::position_nudge(x = -0.025, y = 0), ...,
+                           color_dots = NULL, fill_dots = NULL) {
 
   if(is.null(color_dots) & is.null(fill_dots)){
     dotplot <- geom_dotplot(

--- a/R/geom_violindot.R
+++ b/R/geom_violindot.R
@@ -20,9 +20,9 @@
 #' @import ggplot2
 #' @export
 geom_violindot <- function(mapping = NULL, data = NULL, trim = TRUE, scale = "area",
-                           show.legend = NA, inherit.aes = TRUE, size_dots = 0.7, dots_color = NULL, dots_fill = NULL,
+                           show.legend = NA, inherit.aes = TRUE, dots_size = 0.7, dots_color = NULL, dots_fill = NULL,
                            binwidth = 0.05, position_dots = ggplot2::position_nudge(x = -0.025, y = 0), ...,
-                           color_dots = dots_color, fill_dots = dots_fill) {
+                           size_dots = dots_size, color_dots = dots_color, fill_dots = dots_fill) {
 
   if(is.null(color_dots) & is.null(fill_dots)){
     dotplot <- geom_dotplot(

--- a/R/geom_violindot.R
+++ b/R/geom_violindot.R
@@ -20,9 +20,9 @@
 #' @import ggplot2
 #' @export
 geom_violindot <- function(mapping = NULL, data = NULL, trim = TRUE, scale = "area",
-                           show.legend = NA, inherit.aes = TRUE, size_dots = 0.7,
+                           show.legend = NA, inherit.aes = TRUE, size_dots = 0.7, dots_color = NULL, dots_fill = NULL,
                            binwidth = 0.05, position_dots = ggplot2::position_nudge(x = -0.025, y = 0), ...,
-                           color_dots = NULL, fill_dots = NULL) {
+                           color_dots = dots_color, fill_dots = dots_fill) {
 
   if(is.null(color_dots) & is.null(fill_dots)){
     dotplot <- geom_dotplot(

--- a/R/geom_violindot.R
+++ b/R/geom_violindot.R
@@ -20,8 +20,8 @@
 #' @import ggplot2
 #' @export
 geom_violindot <- function(mapping = NULL, data = NULL, trim = TRUE, scale = "area",
-                           show.legend = NA, inherit.aes = TRUE, size_dots = 0.7, color_dots=NULL, fill_dots=NULL,
-                           binwidth=0.05, position_dots = ggplot2::position_nudge(x = -0.025, y = 0), ...) {
+                           show.legend = NA, inherit.aes = TRUE, size_dots = 0.7, color_dots=NULL,
+                           binwidth=0.05, position_dots = ggplot2::position_nudge(x = -0.025, y = 0), ..., fill_dots=NULL) {
 
   if(is.null(color_dots) & is.null(fill_dots)){
     dotplot <- geom_dotplot(


### PR DESCRIPTION
Moving the `fill_dots` and `color_dots` arguments to after `...` allows the `fill` and `color` arguments to apply to both dots and violins. This fixes issue #84.
```
ggplot(iris, aes(x = Species, y = Sepal.Length)) +
  geom_violindot(fill = "blue") +
  theme_modern()
```

![](https://i.imgur.com/8k86Gu6.png)

This may occur because of partial matching in function arguments. A drawback to this solution is that the order of arguments changes, which is not backwards compatible (though it seems unlikely that this is a major problem since they are the eighth and ninth arguments). I'm open to other possibilities.