### PR TITLE
Make observed variables square in sem plot

### DIFF
--- a/R/plot.parameters_sem.R
+++ b/R/plot.parameters_sem.R
@@ -113,7 +113,7 @@ plot.see_parameters_sem <- function(x, data = NULL, type = c("regression", "corr
     arrow = arrow(type = "closed", length = unit(3, "mm")),
     start_cap = ggraph::circle(12, "mm"), end_cap = ggraph::circle(12, "mm")
     ) +
-    ggraph::geom_node_point(aes(colour = .data$Latent), size = size_point) +
+    ggraph::geom_node_point(aes(colour = .data$Latent, shape = .data$Latent), size = size_point) +
     ggraph::geom_node_text(aes(label = .data$Name)) +
     ggraph::scale_edge_colour_gradient2(
       guide = FALSE,
@@ -122,6 +122,7 @@ plot.see_parameters_sem <- function(x, data = NULL, type = c("regression", "corr
       low = "#E91E63"
     ) +
     scale_alpha(guide = FALSE, range = c(0, 1)) +
+    scale_shape_manual(values = c(`FALSE` = 15, `TRUE` = 19)) +
     ggraph::scale_edge_alpha(guide = FALSE, range = c(0, 1)) +
     scale_x_continuous(expand = expansion(c(.10, .10))) +
     scale_y_continuous(expand = expansion(c(.10, .10))) +


### PR DESCRIPTION
@DominiqueMakowski You can specify a shape parameter for `geom_node_point()`. shape = 15 is a filled square, shape = 19 is the default filled circle

Addresses https://github.com/easystats/see/issues/95