### PR TITLE
explicitly specify formula for smooth geom

### DIFF
--- a/R/plot.check_heteroscedasticity.R
+++ b/R/plot.check_heteroscedasticity.R
@@ -65,8 +65,8 @@ plot.see_check_heteroscedasticity <- function(x, data = NULL, ...) {
   }
   betad <- model$fit$par["betad"]
   switch(faminfo$family,
-         gaussian = exp(0.5 * betad),
-         Gamma = exp(-0.5 * betad),
-         exp(betad)
+    gaussian = exp(0.5 * betad),
+    Gamma = exp(-0.5 * betad),
+    exp(betad)
   )
 }

--- a/R/plot.parameters_sem.R
+++ b/R/plot.parameters_sem.R
@@ -55,10 +55,14 @@ data_plot.parameters_sem <- function(x, data = NULL, component = c("regression",
   edges <- edges[colSums(!is.na(edges)) > 0]
 
   # Identify nodes
-  latent_nodes <- data.frame(Name = as.character(edges[edges$Component == "Loading", "to"]),
-                             Latent = TRUE)
-  manifest_nodes <- data.frame(Name = unique(c(edges$from, edges$to)),
-                               Latent = FALSE)
+  latent_nodes <- data.frame(
+    Name = as.character(edges[edges$Component == "Loading", "to"]),
+    Latent = TRUE
+  )
+  manifest_nodes <- data.frame(
+    Name = unique(c(edges$from, edges$to)),
+    Latent = FALSE
+  )
   manifest_nodes <- manifest_nodes[!manifest_nodes$Name %in% latent_nodes$Name, ]
   nodes <- rbind(manifest_nodes, latent_nodes)
 

--- a/R/print.binned_residuals.R
+++ b/R/print.binned_residuals.R
@@ -36,6 +36,7 @@ print.see_binned_residuals <- function(x, ...) {
         aes(y = .data$ybar),
         method = "loess",
         se = FALSE,
+        formula = y ~ x,
         colour = "#00b159",
         size = .6
       )

--- a/R/print.check_model.R
+++ b/R/print.check_model.R
@@ -142,7 +142,8 @@ print.see_check_model <- function(x, style = theme_lucid, colors = c("#3aaf85", 
         detrend = detrend
       ),
       qqplotr::stat_qq_point(
-        shape = 16, stroke = 0,
+        shape = 16,
+        stroke = 0,
         size = size_point,
         colour = colors[2], # "#2c3e50",
         alpha = dot_alpha_level,
@@ -243,6 +244,7 @@ print.see_check_model <- function(x, style = theme_lucid, colors = c("#3aaf85", 
       method = "loess",
       se = TRUE,
       alpha = alpha_level,
+      formula = y ~ x,
       size = size_line,
       colour = colors[1]
     ) +
@@ -267,6 +269,7 @@ print.see_check_model <- function(x, style = theme_lucid, colors = c("#3aaf85", 
     geom_smooth(
       method = "loess",
       se = TRUE,
+      formula = y ~ x,
       alpha = alpha_level,
       size = size_line,
       colour = colors[1]
@@ -297,6 +300,7 @@ print.see_check_model <- function(x, style = theme_lucid, colors = c("#3aaf85", 
         method = "lm",
         alpha = alpha_level,
         size = size_line,
+        formula = y ~ x,
         colour = colors[1]
       ) +
       geom_errorbar(


### PR DESCRIPTION
Avoid warning about formula every time the functions are used.