### PR TITLE
use markdown syntax in roxygen docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -96,5 +96,6 @@ Suggests:
     vdiffr (>= 1.0.0)
 Encoding: UTF-8
 Language: en-US
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
 Config/testthat/edition: 3

--- a/R/coord_radar.R
+++ b/R/coord_radar.R
@@ -3,10 +3,10 @@
 #' Add a radar coordinate system useful for radar charts.
 #'
 #' @param theta Can be 'x' or 'y'.
-#' @param start Starting position. Best expressed in terms of \code{pi} (e.g.,
-#'   \code{-pi/4}).
+#' @param start Starting position. Best expressed in terms of `pi` (e.g.,
+#'   `-pi/4`).
 #' @param direction The direction of plotting. Can be 1 or -1.
-#' @param ... Other arguments to be passed to \code{ggproto}.
+#' @param ... Other arguments to be passed to `ggproto`.
 #'
 #' @examples
 #' # Create a radar/spider chart with ggplot:

--- a/R/data_plot.R
+++ b/R/data_plot.R
@@ -101,7 +101,8 @@ data_plot <- function(x, data = NULL, ...) {
 
 #' Complete figure with its attributes
 #'
-#' The [data_plot] function usually stores information (such as title, axes labels etc.) as attributes. This function adds those information to the plot.
+#' The [data_plot] function usually stores information (such as title, axes
+#' labels etc.) as attributes. This function adds those information to the plot.
 #'
 #' @inheritParams data_plot
 #' @examples

--- a/R/data_plot.R
+++ b/R/data_plot.R
@@ -1,10 +1,10 @@
 #' @title Prepare objects for plotting or plot objects
 #' @name data_plot
 #'
-#' @description \code{data_plot()} attempts to extract and transform an object
-#'   to be further plotted, while \code{plot()} tries to visualize results of
+#' @description `data_plot()` attempts to extract and transform an object
+#'   to be further plotted, while `plot()` tries to visualize results of
 #'   functions from different packages of the
-#'   \href{https://github.com/easystats}{easystats-project}. See the
+#'   [easystats-project](https://github.com/easystats). See the
 #'   documentation for your object's class:
 #' \itemize{
 #'  \item{\link[=plot.see_bayesfactor_models]{bayestestR::bayesfactor_models()}}
@@ -42,20 +42,20 @@
 #'   statistical model or such.
 #' @param ... Arguments passed to or from other methods.
 #'
-#' @details \code{data_plot()} is in most situation not needed when the purpose
-#' is plotting, since most \code{plot()}-functions in \pkg{see} internally call
-#' \code{data_plot()} to prepare the data for plotting.
+#' @details `data_plot()` is in most situation not needed when the purpose
+#' is plotting, since most `plot()`-functions in \pkg{see} internally call
+#' `data_plot()` to prepare the data for plotting.
 #' \cr \cr
-#' Many \code{plot()}-functions have a \code{data}-argument that is needed when
-#' the data or model for plotting can't be retrieved via \code{data_plot()}. In
-#' such cases, \code{plot()} gives an error and asks for providing data or models.
+#' Many `plot()`-functions have a `data`-argument that is needed when
+#' the data or model for plotting can't be retrieved via `data_plot()`. In
+#' such cases, `plot()` gives an error and asks for providing data or models.
 #' \cr \cr
-#' Most \code{plot()}-functions work out-of-the-box, i.e. you don't need to do
-#' much more than calling \code{plot(<object>)} (see 'Examples'). Some plot-functions
+#' Most `plot()`-functions work out-of-the-box, i.e. you don't need to do
+#' much more than calling `plot(<object>)` (see 'Examples'). Some plot-functions
 #' allow to specify arguments to modify the transparency or color of geoms, these
 #' are shown in the 'Usage' section.
 #'
-#' @seealso \href{https://easystats.github.io/see/articles/}{Package-Vignettes}
+#' @seealso [Package-Vignettes](https://easystats.github.io/see/articles/)
 #'
 #' @examples
 #' \dontrun{
@@ -101,7 +101,7 @@ data_plot <- function(x, data = NULL, ...) {
 
 #' Complete figure with its attributes
 #'
-#' The \link{data_plot} function usually stores information (such as title, axes labels etc.) as attributes. This function adds those information to the plot.
+#' The [data_plot] function usually stores information (such as title, axes labels etc.) as attributes. This function adds those information to the plot.
 #'
 #' @inheritParams data_plot
 #' @examples

--- a/R/geom_binomdensity.R
+++ b/R/geom_binomdensity.R
@@ -1,13 +1,13 @@
 #' Add dot-densities for binary y variables
 #'
 #' @param data A dataframe.
-#' @param x,y Characters corresponding to the x and y axis. Note that \code{y}
+#' @param x,y Characters corresponding to the x and y axis. Note that `y`
 #'   must be a variable with two unique values.
 #' @param scale Method of scaling the dot-densities. Can be 'auto'
 #'   (corresponding to the square root of the proportion), 'proportion',
 #'   'density' or a custom list with values for each factor level (see
 #'   examples).
-#' @param ... Other arguments passed to \code{ggdist::geom_dots}.
+#' @param ... Other arguments passed to `ggdist::geom_dots`.
 #'
 #' @examples
 #' library(ggplot2)

--- a/R/geom_from_list.R
+++ b/R/geom_from_list.R
@@ -1,14 +1,14 @@
 #' Create ggplot2 geom(s) from a list
 #'
-#' These helper functions are built on top of \code{ggplot2::layer()} and can be
+#' These helper functions are built on top of `ggplot2::layer()` and can be
 #' used to add geom(s) which type and content is specified as a list.
 #'
-#' @param x A list containing a geom type (e.g., \code{geom = "point"}), a list
-#'   of aesthetics (as characters; e.g., \code{aes = list(x = "mpg", y =
-#'   "wt")}), some data (e.g., \code{data = mtcars}) and some other parameters.
-#'   For \code{geoms_from_list()} ("geoms" with an "s"), the input must be a
-#'   list of lists, ideally named \code{"l1", "l2", "l3"}, etc.
-#' @param ... Additional arguments passed to \code{ggplot2::layer()}.
+#' @param x A list containing a geom type (e.g., `geom = "point"`), a list
+#'   of aesthetics (as characters; e.g., `aes = list(x = "mpg", y =
+#'   "wt")`), some data (e.g., `data = mtcars`) and some other parameters.
+#'   For `geoms_from_list()` ("geoms" with an "s"), the input must be a
+#'   list of lists, ideally named `"l1", "l2", "l3"`, etc.
+#' @param ... Additional arguments passed to `ggplot2::layer()`.
 #'
 #'
 #' @examples

--- a/R/geom_point2.R
+++ b/R/geom_point2.R
@@ -7,13 +7,13 @@
 #' @param stroke Stroke thickness.
 #' @param shape Shape of points.
 #' @param ... Other arguments to be passed to
-#'   \code{\link[ggplot2:geom_point]{geom_point}},
-#'   \code{\link[ggplot2:geom_jitter]{geom_jitter}},
-#'   \code{\link[ggplot2:geom_pointrange]{geom_pointrange}}, or
-#'   \code{\link[ggplot2:geom_count]{ggplot2::geom_count}}.
+#'   [ggplot2::geom_point()],
+#'   [ggplot2::geom_jitter()],
+#'   [ggplot2::geom_pointrange()], or
+#'   [ggplot2::geom_count()].
 #'
-#' @note The color aesthetics for \code{geom_point_borderless()} is
-#'   \code{"fill"}, not \code{color}. See 'Examples'.
+#' @note The color aesthetics for `geom_point_borderless()` is
+#'   `"fill"`, not `color`. See 'Examples'.
 #'
 #' @examples
 #' library(ggplot2)

--- a/R/geom_poolpoint.R
+++ b/R/geom_poolpoint.R
@@ -7,7 +7,7 @@
 #' @param size_background Size of the white background circle.
 #' @param size_point Size of the ball.
 #' @param jitter Width and height of position jitter.
-#' @param ... Other arguments to be passed to \code{geom_point}.
+#' @param ... Other arguments to be passed to `geom_point`.
 #'
 #' @examples
 #' library(ggplot2)

--- a/R/geom_violinhalf.R
+++ b/R/geom_violinhalf.R
@@ -12,7 +12,6 @@
 #'   geom_violinhalf() +
 #'   theme_modern() +
 #'   scale_fill_material_d()
-#'
 #' @import ggplot2
 #' @export
 geom_violinhalf <- function(mapping = NULL,

--- a/R/golden_ratio.R
+++ b/R/golden_ratio.R
@@ -2,7 +2,7 @@
 #'
 #' Returns the golden ratio (1.618034...). Useful to easily obtain golden
 #' proportions, for instance for a horizontal figure, if you want its height to
-#' be 8, you can set its width to be \code{golden_ratio(8)}.
+#' be 8, you can set its width to be `golden_ratio(8)`.
 #'
 #' @param x A number to be multiplied by the golden ratio. The default (x=1)
 #'   returns the value of the golden ratio.

--- a/R/plot.bayesfactor_models.R
+++ b/R/plot.bayesfactor_models.R
@@ -1,23 +1,23 @@
 #' Plot method for Bayes Factors for model comparison
 #'
-#' The \code{plot()} method for the \code{bayestestR::bayesfactor_models()} function.
-#' These plots visualize the \strong{posterior probabilities} of the compared models.
+#' The `plot()` method for the `bayestestR::bayesfactor_models()` function.
+#' These plots visualize the **posterior probabilities** of the compared models.
 #'
 #' @param n_pies Number of pies.
 #' @param value What value to display.
 #' @param sort \describe{
-#'   \item{\emph{Plotting model parameters}}{
-#'   If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
+#'   \item{*Plotting model parameters*}{
+#'   If `NULL`, coefficients are plotted in the order as they appear in the summary. Use `sort = "ascending"` (or `sort = TRUE`)) resp. `sort = "descending"` to sort coefficients in ascending or descending order.
 #'   }
-#'   \item{\emph{Plotting Bayes factors}}{
+#'   \item{*Plotting Bayes factors*}{
 #'   Sort pie-slices by posterior probability (descending)?
 #'   }
 #' }
 #' @param log Show log-transformed Bayes factors.
 #' @param prior_odds optional vector of prior odds for the models. See
-#'   \code{BayesFactor::priorOdds}. As the size of the pizza slices corresponds
+#'   `BayesFactor::priorOdds`. As the size of the pizza slices corresponds
 #'   to posterior probability (which is a function of prior probability and the BF),
-#'   custom \code{prior_odds} will change the slices' size.
+#'   custom `prior_odds` will change the slices' size.
 #' @inheritParams data_plot
 #'
 #' @return A ggplot2-object.

--- a/R/plot.bayesfactor_models.R
+++ b/R/plot.bayesfactor_models.R
@@ -7,7 +7,9 @@
 #' @param value What value to display.
 #' @param sort \describe{
 #'   \item{*Plotting model parameters*}{
-#'   If `NULL`, coefficients are plotted in the order as they appear in the summary. Use `sort = "ascending"` (or `sort = TRUE`)) resp. `sort = "descending"` to sort coefficients in ascending or descending order.
+#'   If `NULL`, coefficients are plotted in the order as they appear in the
+#'   summary. Use `sort = "ascending"` (or `sort = TRUE`)) resp. `sort =
+#'   "descending"` to sort coefficients in ascending or descending order.
 #'   }
 #'   \item{*Plotting Bayes factors*}{
 #'   Sort pie-slices by posterior probability (descending)?
@@ -15,9 +17,9 @@
 #' }
 #' @param log Show log-transformed Bayes factors.
 #' @param prior_odds optional vector of prior odds for the models. See
-#'   `BayesFactor::priorOdds`. As the size of the pizza slices corresponds
-#'   to posterior probability (which is a function of prior probability and the BF),
-#'   custom `prior_odds` will change the slices' size.
+#'   `BayesFactor::priorOdds`. As the size of the pizza slices corresponds to
+#'   posterior probability (which is a function of prior probability and the
+#'   BF), custom `prior_odds` will change the slices' size.
 #' @inheritParams data_plot
 #'
 #' @return A ggplot2-object.

--- a/R/plot.bayesfactor_parameters.R
+++ b/R/plot.bayesfactor_parameters.R
@@ -1,11 +1,11 @@
 #' Plot method for Bayes Factors for a single parameter
 #'
-#' The \code{plot()} method for the \code{bayestestR::bayesfactor_parameters()} function.
+#' The `plot()` method for the `bayestestR::bayesfactor_parameters()` function.
 #'
 #' @param size_point Size of point-geoms.
 #' @param rope_alpha Transparency level of ROPE ribbon.
 #' @param rope_color Color of ROPE ribbon.
-#' @param show_intercept Logical, if \code{TRUE}, the intercept-parameter is included
+#' @param show_intercept Logical, if `TRUE`, the intercept-parameter is included
 #'   in the plot. By default, it is hidden because in many cases the intercept-parameter
 #'   has a posterior distribution on a very different location, so density curves of
 #'   posterior distributions for other parameters are hardly visible.

--- a/R/plot.check_collinearity.R
+++ b/R/plot.check_collinearity.R
@@ -1,6 +1,6 @@
 #' Plot method for multicollinearity checks
 #'
-#' The \code{plot()} method for the \code{performance::check_collinearity()} function.
+#' The `plot()` method for the `performance::check_collinearity()` function.
 #'
 #' @inheritParams data_plot
 #' @inheritParams plot.see_check_normality

--- a/R/plot.check_distribution.R
+++ b/R/plot.check_distribution.R
@@ -1,9 +1,9 @@
 #' Plot method for classifying the distribution of a model-family
 #'
-#' The \code{plot()} method for the \code{performance::check_distribution()}
+#' The `plot()` method for the `performance::check_distribution()`
 #' function.
 #'
-#' @param panel Logical, if \code{TRUE}, plots are arranged as panels; else,
+#' @param panel Logical, if `TRUE`, plots are arranged as panels; else,
 #'   single plots are returned.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.check_heteroscedasticity.R
+++ b/R/plot.check_heteroscedasticity.R
@@ -1,7 +1,7 @@
 #' Plot method for (non-)constant error variance checks
 #'
-#' The \code{plot()} method for the
-#' \code{performance::check_heteroscedasticity()} function.
+#' The `plot()` method for the
+#' `performance::check_heteroscedasticity()` function.
 #'
 #' @inheritParams data_plot
 #'

--- a/R/plot.check_homogeneity.R
+++ b/R/plot.check_homogeneity.R
@@ -1,6 +1,6 @@
 #' Plot method for homogeneity of variances checks
 #'
-#' The \code{plot()} method for the \code{performance::check_homogeneity()}
+#' The `plot()` method for the `performance::check_homogeneity()`
 #' function.
 #'
 #' @inheritParams data_plot

--- a/R/plot.check_normality.R
+++ b/R/plot.check_normality.R
@@ -1,6 +1,6 @@
 #' Plot method for check model for (non-)normality of residuals
 #'
-#' The \code{plot()} method for the \code{performance::check_normality()}
+#' The `plot()` method for the `performance::check_normality()`
 #' function.
 #'
 #' @param type Character vector, indicating the type of plot.

--- a/R/plot.check_outliers.R
+++ b/R/plot.check_outliers.R
@@ -1,10 +1,10 @@
 #' Plot method for checking outliers
 #'
-#' The \code{plot()} method for the \code{performance::check_outliers()}
+#' The `plot()` method for the `performance::check_outliers()`
 #' function.
 #'
 #' @param size_text Size of text labels.
-#' @param rescale_distance Logical, if \code{TRUE}, distance values are rescaled
+#' @param rescale_distance Logical, if `TRUE`, distance values are rescaled
 #'   to a range from 0 to 1. This is mainly due to better catch the differences
 #'   between distance values.
 #' @inheritParams data_plot

--- a/R/plot.cluster_analysis.R
+++ b/R/plot.cluster_analysis.R
@@ -28,12 +28,12 @@ data_plot.cluster_analysis <- function(x, data = NULL, ...) {
 
 #' Plot method for computing cluster analysis
 #'
-#' The \code{plot()} method for the \code{parameters::cluster_analysis()}
+#' The `plot()` method for the `parameters::cluster_analysis()`
 #' function.
 #'
 #' @param n_columns For models with multiple components (like fixed and random,
 #'   count and zero-inflated), defines the number of columns for the
-#'   panel-layout. If \code{NULL}, a single, integrated plot is shown.
+#'   panel-layout. If `NULL`, a single, integrated plot is shown.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_check_normality
 #' @inheritParams plot.see_parameters_distribution

--- a/R/plot.compare_parameters.R
+++ b/R/plot.compare_parameters.R
@@ -27,14 +27,13 @@
 #' }
 #' @export
 plot.see_compare_parameters <- function(x,
-           show_intercept = FALSE,
-           size_point = .8,
-           size_text = NULL,
-           dodge_position = .8,
-           sort = NULL,
-           n_columns = NULL,
-           ...) {
-
+                                        show_intercept = FALSE,
+                                        size_point = .8,
+                                        size_text = NULL,
+                                        dodge_position = .8,
+                                        sort = NULL,
+                                        n_columns = NULL,
+                                        ...) {
   if (!"data_plot" %in% class(x)) {
     x <- data_plot(x)
   }

--- a/R/plot.compare_parameters.R
+++ b/R/plot.compare_parameters.R
@@ -1,6 +1,6 @@
 #' Plot method for comparison of model parameters
 #'
-#' The \code{plot()} method for the \code{parameters::compare_parameters()}
+#' The `plot()` method for the `parameters::compare_parameters()`
 #' function.
 #'
 #' @param dodge_position Numeric, indicates the amount of "dodging" (spacing)

--- a/R/plot.compare_performance.R
+++ b/R/plot.compare_performance.R
@@ -44,7 +44,7 @@ data_plot.compare_performance <- function(x, data = NULL, ...) {
 # Plot --------------------------------------------------------------------
 #' Plot method for comparing model performances
 #'
-#' The \code{plot()} method for the \code{performance::compare_performance()} function.
+#' The `plot()` method for the `performance::compare_performance()` function.
 #'
 #' @inheritParams data_plot
 #' @inheritParams plot.see_check_normality

--- a/R/plot.describe_distribution.R
+++ b/R/plot.describe_distribution.R
@@ -29,16 +29,16 @@ data_plot.parameters_distribution <- function(x, data = NULL, ...) {
 # Plot --------------------------------------------------------------------
 #' Plot method for describing distributions of vectors
 #'
-#' The \code{plot()} method for the \code{parameters::describe_distribution()}
+#' The `plot()` method for the `parameters::describe_distribution()`
 #' function.
 #'
-#' @param dispersion Logical, if \code{TRUE}, will add range of dispersion for
+#' @param dispersion Logical, if `TRUE`, will add range of dispersion for
 #'   each variable to the plot.
 #' @param dispersion_alpha Transparency level of dispersion ribbon.
 #' @param dispersion_color Color of dispersion ribbon.
-#' @param dispersion_style Character, style of dispersion area. \code{"ribbon"}
-#'   for a ribbon, \code{"curve"} for a normal-curve.
-#' @param highlight Vector with names of categories in \code{x} that should be
+#' @param dispersion_style Character, style of dispersion area. `"ribbon"`
+#'   for a ribbon, `"curve"` for a normal-curve.
+#' @param highlight Vector with names of categories in `x` that should be
 #'   highlighted.
 #' @param highlight_color Vector of color values for highlighted categories. The
 #'   remaining (non-highlighted) categories will be filled with a lighter grey.

--- a/R/plot.easycormatrix.R
+++ b/R/plot.easycormatrix.R
@@ -81,15 +81,14 @@ data_plot.see_easycormatrix <- function(x, data = NULL, digits = 3, size = 1, ..
 #' plot(s)
 #' @export
 plot.see_easycormatrix <- function(x,
-           show_values = FALSE,
-           show_p = FALSE,
-           show_legend = TRUE,
-           size_point = 1,
-           size_text = 3.5,
-           digits = 3,
-           type = c("circle", "tile"),
-           ...) {
-
+                                   show_values = FALSE,
+                                   show_p = FALSE,
+                                   show_legend = TRUE,
+                                   size_point = 1,
+                                   size_text = 3.5,
+                                   digits = 3,
+                                   type = c("circle", "tile"),
+                                   ...) {
   if (!"data_plot" %in% class(x)) {
     x <- data_plot(x, digits = digits, size = size_point)
   }

--- a/R/plot.easycormatrix.R
+++ b/R/plot.easycormatrix.R
@@ -59,10 +59,10 @@ data_plot.see_easycormatrix <- function(x, data = NULL, digits = 3, size = 1, ..
 
 #' Plot method for correlation matrices
 #'
-#' The \code{plot()} method for the \code{correlation::correlation()} function.
+#' The `plot()` method for the `correlation::correlation()` function.
 #'
-#' @param show_values Logical, if \code{TRUE}, values are displayed.
-#' @param show_p Logical, if \code{TRUE}, p-values or significant level is
+#' @param show_values Logical, if `TRUE`, values are displayed.
+#' @param show_p Logical, if `TRUE`, p-values or significant level is
 #'   displayed.
 #' @param show_legend Logical, show or hide legend.
 #' @param digits Number of decimals used for values.

--- a/R/plot.easycorrelation.R
+++ b/R/plot.easycorrelation.R
@@ -1,6 +1,6 @@
 #' Plot method for Gaussian Graphical Models
 #'
-#' The \code{plot()} method for the \code{correlation::correlation()} function.
+#' The `plot()` method for the `correlation::correlation()` function.
 #'
 #' @param node_color Color of node- or circle-geoms.
 #' @param text_color Color of text labels.

--- a/R/plot.effectsize_table.R
+++ b/R/plot.effectsize_table.R
@@ -1,6 +1,6 @@
 #' Plot method for effect size tables
 #'
-#' The \code{plot()} method for the \code{effectsize::effectsize()} function.
+#' The `plot()` method for the `effectsize::effectsize()` function.
 #'
 #' @inheritParams data_plot
 #'

--- a/R/plot.effectsize_table.R
+++ b/R/plot.effectsize_table.R
@@ -89,4 +89,3 @@ plot.see_equivalence_test_effectsize <- function(x, ...) {
     ) +
     theme_modern()
 }
-

--- a/R/plot.equivalence_test.R
+++ b/R/plot.equivalence_test.R
@@ -1,6 +1,6 @@
 #' Plot method for (conditional) equivalence testing
 #'
-#' The \code{plot()} method for the \code{bayestestR::equivalence_test()} function.
+#' The `plot()` method for the `bayestestR::equivalence_test()` function.
 #'
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.estimate_contrasts.R
+++ b/R/plot.estimate_contrasts.R
@@ -62,7 +62,7 @@ data_plot.estimate_contrasts <- function(x, data = NULL, ...) {
 
 #' Plot method for estimating contrasts
 #'
-#' The \code{plot()} method for the \code{modelbased::estimate_contrasts()}
+#' The `plot()` method for the `modelbased::estimate_contrasts()`
 #' function.
 #'
 #' @inheritParams data_plot

--- a/R/plot.estimate_density.R
+++ b/R/plot.estimate_density.R
@@ -67,17 +67,17 @@ data_plot.estimate_density <- function(x,
 
 #' Plot method for density estimation of posterior samples
 #'
-#' The \code{plot()} method for the \code{bayestestR::estimate_density()} function.
+#' The `plot()` method for the `bayestestR::estimate_density()` function.
 #'
-#' @param stack Logical, if \code{TRUE}, densities are plotted as stacked lines.
+#' @param stack Logical, if `TRUE`, densities are plotted as stacked lines.
 #'   Else, densities are plotted for each parameter among each other.
-#' @param priors Logical, if \code{TRUE}, prior distributions are simulated
-#'   (using \code{\link[bayestestR:simulate_prior]{simulate_prior()}}) and added
+#' @param priors Logical, if `TRUE`, prior distributions are simulated
+#'   (using [bayestestR::simulate_prior()]) and added
 #'   to the plot.
 #' @param priors_alpha Alpha value of the prior distributions.
 #' @param posteriors_alpha Alpha value of the posterior distributions.
 #' @param centrality The point-estimate (centrality index) to compute. May be
-#'   \code{"median"}, \code{"mean"} or \code{"MAP"}.
+#'   `"median"`, `"mean"` or `"MAP"`.
 #' @param ci Value of probability of the CI (between 0 and 1) to be estimated.
 #'   Default to .95.
 #' @inheritParams data_plot

--- a/R/plot.hdi.R
+++ b/R/plot.hdi.R
@@ -181,12 +181,12 @@ data_plot.bayestestR_eti <- data_plot.hdi
 
 #' Plot method for uncertainty or credible intervals
 #'
-#' The \code{plot()} method for the \code{bayestestR::hdi()} and related
+#' The `plot()` method for the `bayestestR::hdi()` and related
 #' function.
 #'
-#' @param show_zero Logical, if \code{TRUE}, will add a vertical (dotted) line
+#' @param show_zero Logical, if `TRUE`, will add a vertical (dotted) line
 #'   at 0.
-#' @param show_title Logical, if \code{TRUE}, will show the title of the plot.
+#' @param show_title Logical, if `TRUE`, will show the title of the plot.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters
 #' @inheritParams plot.see_cluster_analysis

--- a/R/plot.n_factors.R
+++ b/R/plot.n_factors.R
@@ -64,9 +64,9 @@ data_plot.n_clusters <- data_plot.n_factors
 
 #' Plot method for numbers of clusters to extract or factors to retain
 #'
-#' The \code{plot()} method for the \code{parameters::n_factors()} and \code{parameters::n_clusters()}
+#' The `plot()` method for the `parameters::n_factors()` and `parameters::n_clusters()`
 #'
-#' @param size Depending on \code{type}, size of bars, lines or segments.
+#' @param size Depending on `type`, size of bars, lines or segments.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_check_normality
 #'

--- a/R/plot.p_direction.R
+++ b/R/plot.p_direction.R
@@ -141,7 +141,7 @@ data_plot.p_direction <- function(x, data = NULL, show_intercept = FALSE, ...) {
 
 #' Plot method for probability of direction
 #'
-#' The \code{plot()} method for the \code{bayestestR::p_direction()} function.
+#' The `plot()` method for the `bayestestR::p_direction()` function.
 #'
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.p_significance.R
+++ b/R/plot.p_significance.R
@@ -150,7 +150,7 @@ data_plot.p_significance <- function(x,
 
 #' Plot method for practical significance
 #'
-#' The \code{plot()} method for the \code{bayestestR::p_significance()} function.
+#' The `plot()` method for the `bayestestR::p_significance()` function.
 #'
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.parameters_brms_meta.R
+++ b/R/plot.parameters_brms_meta.R
@@ -64,13 +64,13 @@ data_plot.parameters_brms_meta <- function(x, data = NULL, normalize_height = TR
 
 #' Plot method for Model Parameters from Bayesian Meta-Analysis
 #'
-#' The \code{plot()} method for the \code{parameters::model_parameters()}
+#' The `plot()` method for the `parameters::model_parameters()`
 #' function when used with brms-meta-analysis models.
 #'
-#' @param normalize_height Logical, if \code{TRUE}, height of mcmc-areas is
+#' @param normalize_height Logical, if `TRUE`, height of mcmc-areas is
 #'   "normalized", to avoid overlap. In certain cases when the range of a
 #'   posterior distribution is narrow for some parameters, this may result in
-#'   very flat mcmc-areas. In such cases, set \code{normalize_height = FALSE}.
+#'   very flat mcmc-areas. In such cases, set `normalize_height = FALSE`.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_rope
 #' @inheritParams plot.see_check_normality
@@ -82,14 +82,14 @@ data_plot.parameters_brms_meta <- function(x, data = NULL, normalize_height = TR
 #'
 #' @details
 #' \subsection{Colors of density areas and errorbars}{
-#'   To change the colors of the density areas, use \code{scale_fill_manual()}
-#'   with named color-values, e.g. \code{scale_fill_manual(values = c("Study" =
-#'   "blue", "Overall" = "green"))}.
-#'   To change the color of the error bars, use \code{scale_color_manual(values
-#'   = c("Errorbar" = "red"))}.
+#'   To change the colors of the density areas, use `scale_fill_manual()`
+#'   with named color-values, e.g. `scale_fill_manual(values = c("Study" =
+#'   "blue", "Overall" = "green"))`.
+#'   To change the color of the error bars, use `scale_color_manual(values
+#'   = c("Errorbar" = "red"))`.
 #' }
 #' \subsection{Show or hide estimates and CI}{
-#'   Use \code{size_text = NULL} or \code{size_text = NA} to hide the textual
+#'   Use `size_text = NULL` or `size_text = NA` to hide the textual
 #'   output of estimates and credible intervals.
 #' }
 #'

--- a/R/plot.parameters_model.R
+++ b/R/plot.parameters_model.R
@@ -1,10 +1,10 @@
 #' Plot method for model parameters
 #'
-#' The \code{plot()} method for the \code{parameters::model_parameters()} function.
+#' The `plot()` method for the `parameters::model_parameters()` function.
 #'
 #' @param type Indicating the type of plot. Only applies for model parameters from meta-analysis objects (e.g. \pkg{metafor}).
 #' @param component Indicate which component of the model should be plotted.
-#' @param weight_points Logical, if \code{TRUE}, for meta-analysis objects, point size will be adjusted according to the study-weights.
+#' @param weight_points Logical, if `TRUE`, for meta-analysis objects, point size will be adjusted according to the study-weights.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters
 #' @inheritParams plot.see_bayesfactor_models

--- a/R/plot.parameters_model.R
+++ b/R/plot.parameters_model.R
@@ -2,9 +2,11 @@
 #'
 #' The `plot()` method for the `parameters::model_parameters()` function.
 #'
-#' @param type Indicating the type of plot. Only applies for model parameters from meta-analysis objects (e.g. \pkg{metafor}).
+#' @param type Indicating the type of plot. Only applies for model parameters
+#'   from meta-analysis objects (e.g. \pkg{metafor}).
 #' @param component Indicate which component of the model should be plotted.
-#' @param weight_points Logical, if `TRUE`, for meta-analysis objects, point size will be adjusted according to the study-weights.
+#' @param weight_points Logical, if `TRUE`, for meta-analysis objects, point
+#'   size will be adjusted according to the study-weights.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters
 #' @inheritParams plot.see_bayesfactor_models
@@ -22,15 +24,14 @@
 #' plot(result)
 #' @export
 plot.see_parameters_model <- function(x,
-           show_intercept = FALSE,
-           size_point = .8,
-           size_text = NULL,
-           sort = NULL,
-           n_columns = NULL,
-           type = c("forest", "funnel"),
-           weight_points = TRUE,
-           ...) {
-
+                                      show_intercept = FALSE,
+                                      size_point = .8,
+                                      size_text = NULL,
+                                      sort = NULL,
+                                      n_columns = NULL,
+                                      type = c("forest", "funnel"),
+                                      weight_points = TRUE,
+                                      ...) {
   if (!any(grepl("Coefficient", colnames(x), fixed = TRUE))) {
     colnames(x)[which.min(match(colnames(x), c("Median", "Mean", "Map")))] <- "Coefficient"
   }

--- a/R/plot.parameters_pca.R
+++ b/R/plot.parameters_pca.R
@@ -45,7 +45,7 @@ data_plot.parameters_efa <- data_plot.parameters_pca
 
 #' Plot method for principal component analysis
 #'
-#' The \code{plot()} method for the \code{parameters::principal_components()} function.
+#' The `plot()` method for the `parameters::principal_components()` function.
 #'
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.parameters_simulate.R
+++ b/R/plot.parameters_simulate.R
@@ -60,14 +60,14 @@ data_plot.parameters_simulate <- function(x,
 
 #' Plot method for simulated model parameters
 #'
-#' The \code{plot()} method for the \code{parameters::simulate_parameters()}
+#' The `plot()` method for the `parameters::simulate_parameters()`
 #' function.
 #'
-#' @param normalize_height Logical, if \code{TRUE}, height of density-areas is
+#' @param normalize_height Logical, if `TRUE`, height of density-areas is
 #'   "normalized", to avoid overlap. In certain cases when the range of a
 #'   distribution of simulated draws is narrow for some parameters, this may
 #'   result in very flat density-areas. In such cases, set
-#'   \code{normalize_height = FALSE}.
+#'   `normalize_height = FALSE`.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_estimate_density
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.performance_pp_check.R
+++ b/R/plot.performance_pp_check.R
@@ -37,9 +37,9 @@ data_plot.performance_pp_check <- function(x, ...) {
 
 #' Plot method for posterior predictive checks
 #'
-#' The \code{plot()} method for the \code{performance::pp_check()} function.
+#' The `plot()` method for the `performance::pp_check()` function.
 #'
-#' @param line_alpha Alpha value of lines indicating \code{yrep}.
+#' @param line_alpha Alpha value of lines indicating `yrep`.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_check_normality
 #' @inheritParams plot.see_parameters_distribution

--- a/R/plot.performance_roc.R
+++ b/R/plot.performance_roc.R
@@ -1,6 +1,6 @@
 #' Plot method for ROC curves
 #'
-#' The \code{plot()} method for the \code{performance::performance_roc()}
+#' The `plot()` method for the `performance::performance_roc()`
 #' function.
 #'
 #' @inheritParams data_plot

--- a/R/plot.point_estimates.R
+++ b/R/plot.point_estimates.R
@@ -76,11 +76,11 @@ data_plot.map_estimate <- data_plot.point_estimate
 
 #' Plot method for point estimates of posterior samples
 #'
-#' The \code{plot()} method for the \code{bayestestR::point_estimate()}.
+#' The `plot()` method for the `bayestestR::point_estimate()`.
 #'
-#' @param show_labels Logical, if \code{TRUE}, the text labels for the point
-#'   estimates (i.e. \emph{"Mean"}, \emph{"Median"} and/or \emph{"MAP"}) are
-#'   shown. You may set \code{show_labels = FALSE} in case of overlapping
+#' @param show_labels Logical, if `TRUE`, the text labels for the point
+#'   estimates (i.e. *"Mean"*, *"Median"* and/or *"MAP"*) are
+#'   shown. You may set `show_labels = FALSE` in case of overlapping
 #'   labels, and add your own legend or footnote to the plot.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.point_estimates.R
+++ b/R/plot.point_estimates.R
@@ -164,8 +164,9 @@ plot.see_point_estimate <- function(x,
 
     p_object <- p_object +
       geom_ribbon(aes(ymin = 0, ymax = .data$y),
-                  fill = "#FFC107",
-                  alpha = posterior_alpha)
+        fill = "#FFC107",
+        alpha = posterior_alpha
+      )
 
     if (!is.null(mean_x) && !is.null(mean_y)) {
       p_object <- p_object +

--- a/R/plot.rope.R
+++ b/R/plot.rope.R
@@ -67,7 +67,7 @@ data_plot.rope <- function(x, data = NULL, show_intercept = FALSE, ...) {
 
 #' Plot method for Region of Practical Equivalence
 #'
-#' The \code{plot()} method for the \code{bayestestR::rope()}.
+#' The `plot()` method for the `bayestestR::rope()`.
 #'
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/R/plot.si.R
+++ b/R/plot.si.R
@@ -1,12 +1,12 @@
 #' Plot method for support intervals
 #'
-#' The \code{plot()} method for the \code{bayestestR::si()}.
+#' The `plot()` method for the `bayestestR::si()`.
 #'
 #' @param si_alpha Transparency level of SI ribbon.
 #' @param si_color Color of SI ribbon.
 #' @param support_only Plot only the support data, or show the "raw" prior and
 #'   posterior distributions? Only applies when plotting
-#'   \code{\link[bayestestR]{si}}.
+#'   [bayestestR::si()].
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters
 #' @inheritParams plot.see_cluster_analysis

--- a/R/plots.R
+++ b/R/plots.R
@@ -1,26 +1,26 @@
 #' Multiple plots side by side
 #'
-#' A wrapper around \emph{patchwork} to plot multiple figures side by side on
+#' A wrapper around *patchwork* to plot multiple figures side by side on
 #' the same page. See
-#' \href{https://patchwork.data-imaginist.com/articles/patchwork.html}{the
-#' \emph{patchwork} documentation} for more advanced control of plot layouts.
+#' [the
+#' *patchwork* documentation](https://patchwork.data-imaginist.com/articles/patchwork.html) for more advanced control of plot layouts.
 #'
-#' @param ... Multiple \code{ggplot}s or a list containing \code{ggplot} objects
+#' @param ... Multiple `ggplot`s or a list containing `ggplot` objects
 #' @param n_rows Number of rows to align plots.
 #' @param n_columns Number of columns to align plots.
 #' @param guides A string specifying how guides should be treated in the
-#'   layout. \code{'collect'} will collect shared guides across plots, removing
-#'   duplicates. \code{'keep'} will keep guides alongside their plot.
-#'   \code{'auto'} will inherit from a higher patchwork level (if any). See
-#'   \code{\link[patchwork:plot_layout]{patchwork::plot_layout()}} for details.
-#' @param tags Add tags to your subfigures. Can be \code{NULL} to omit (default)
+#'   layout. `'collect'` will collect shared guides across plots, removing
+#'   duplicates. `'keep'` will keep guides alongside their plot.
+#'   `'auto'` will inherit from a higher patchwork level (if any). See
+#'   [patchwork::plot_layout()] for details.
+#' @param tags Add tags to your subfigures. Can be `NULL` to omit (default)
 #'   or a character vector containing tags for each plot. Automatic tags can
-#'   also be generated with \code{'1'} for Arabic numerals, \code{'A'} for
-#'   uppercase Latin letters, \code{'a'} for lowercase Latin letters, \code{'I'}
-#'   for uppercase Roman numerals, and \code{'i'} for lowercase Roman numerals.
-#'   For backwards compatibility, can also be \code{FALSE} (equivalent to
-#'   \code{NULL}), \code{NA} (equivalent to \code{NULL}), or \code{TRUE}
-#'   (equivalent to \code{'A'}).
+#'   also be generated with `'1'` for Arabic numerals, `'A'` for
+#'   uppercase Latin letters, `'a'` for lowercase Latin letters, `'I'`
+#'   for uppercase Roman numerals, and `'i'` for lowercase Roman numerals.
+#'   For backwards compatibility, can also be `FALSE` (equivalent to
+#'   `NULL`), `NA` (equivalent to `NULL`), or `TRUE`
+#'   (equivalent to `'A'`).
 #' @param tag_prefix,tag_suffix Text strings that should appear before or after
 #'   the tag.
 #' @param tag_sep Text string giving the separator to use between different tag

--- a/R/scale_color_bluebrown.R
+++ b/R/scale_color_bluebrown.R
@@ -1,8 +1,8 @@
 #' Blue-brown color palette
 #'
-#' A blue-brown color palette. Use \code{scale_color_bluebrown_d()} for
-#' \emph{discrete} categories and \code{scale_color_bluebrown_c()} for
-#' a \emph{continuous} scale.
+#' A blue-brown color palette. Use `scale_color_bluebrown_d()` for
+#' *discrete* categories and `scale_color_bluebrown_c()` for
+#' a *continuous* scale.
 #'
 #' @inheritParams palette_bluebrown
 #' @inheritParams scale_color_flat
@@ -110,7 +110,7 @@ bluebrown_colors_list <- c(
 
 #' Extract blue-brown colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the blue-brown color palette. Use \code{bluebrown_colors()} to see all available color.
+#' Can be used to get the hex code of specific colors from the blue-brown color palette. Use `bluebrown_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'
@@ -152,7 +152,7 @@ bluebrown_palettes <- list(
 #' @inheritParams palette_flat
 #'
 #' @details This function is usually not called directly, but from within
-#'   \code{\link[=scale_color_bluebrown]{scale_color_bluebrown()}}.
+#'   [`scale_color_bluebrown()`][scale_color_bluebrown].
 #'
 #' @export
 palette_bluebrown <- function(palette = "contrast", reverse = FALSE, ...) {

--- a/R/scale_color_flat.R
+++ b/R/scale_color_flat.R
@@ -133,7 +133,8 @@ flat_colors_list <- c(
 
 #' Extract Flat UI colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the Flat UI color palette. Use `flat_colors()` to see all available color.
+#' Can be used to get the hex code of specific colors from the Flat UI color
+#' palette. Use `flat_colors()` to see all available color.
 #'
 #' @param ... Character names of colors.
 #'

--- a/R/scale_color_flat.R
+++ b/R/scale_color_flat.R
@@ -1,14 +1,14 @@
 #' Flat UI color palette
 #'
-#' The palette based on \href{https://www.materialui.co/flatuicolors}{Flat UI}.
-#' Use \code{scale_color_flat_d} for \emph{discrete} categories and
-#' \code{scale_color_flat_c} for a \emph{continuous} scale.
+#' The palette based on [Flat UI](https://www.materialui.co/flatuicolors).
+#' Use `scale_color_flat_d` for *discrete* categories and
+#' `scale_color_flat_c` for a *continuous* scale.
 #'
 #' @inheritParams palette_flat
 #' @param discrete Boolean indicating whether color aesthetic is discrete or not.
-#' @param ... Additional arguments passed to \code{discrete_scale()} or
-#'  \code{scale_color_gradientn()}, used respectively when discrete is
-#'  \code{TRUE} or \code{FALSE}.
+#' @param ... Additional arguments passed to `discrete_scale()` or
+#'  `scale_color_gradientn()`, used respectively when discrete is
+#'  `TRUE` or `FALSE`.
 #'
 #' @examples
 #' library(ggplot2)
@@ -133,7 +133,7 @@ flat_colors_list <- c(
 
 #' Extract Flat UI colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the Flat UI color palette. Use \code{flat_colors()} to see all available color.
+#' Can be used to get the hex code of specific colors from the Flat UI color palette. Use `flat_colors()` to see all available color.
 #'
 #' @param ... Character names of colors.
 #'
@@ -173,16 +173,16 @@ flat_palettes <- list(
 
 #' Flat UI color palette
 #'
-#' The palette based on \href{https://www.materialui.co/flatuicolors}{Flat UI}.
+#' The palette based on [Flat UI](https://www.materialui.co/flatuicolors).
 #'
 #' @param palette Character name of palette. Depending on the color scale, can
-#'   be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-#'   \code{"contrast"} or \code{"light"} (for dark themes).
+#'   be `"full"`, `"ice"`, `"rainbow"`, `"complement"`,
+#'   `"contrast"` or `"light"` (for dark themes).
 #' @param reverse Boolean indicating whether the palette should be reversed.
-#' @param ... Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.
+#' @param ... Additional arguments to pass to [`colorRampPalette()`][colorRampPalette].
 #'
 #' @details This function is usually not called directly, but from within
-#'   \code{\link[=scale_color_flat]{scale_color_flat()}}.
+#'   [`scale_color_flat()`][scale_color_flat].
 #'
 #' @export
 palette_flat <- function(palette = "contrast", reverse = FALSE, ...) {

--- a/R/scale_color_material.R
+++ b/R/scale_color_material.R
@@ -1,8 +1,9 @@
 #' Material design color palette
 #'
 #' The palette based on [material design
-#' colors](https://www.materialui.co/color). Use `scale_color_material_d()` for *discrete* categories
-#' and `scale_color_material_c()` for a *continuous* scale.
+#' colors](https://www.materialui.co/color). Use `scale_color_material_d()` for
+#' *discrete* categories and `scale_color_material_c()` for a *continuous*
+#' scale.
 #'
 #' @inheritParams palette_material
 #' @inheritParams scale_color_flat
@@ -133,7 +134,8 @@ material_colors_list <- c(
 
 #' Extract material design colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the material design color palette. Use `material_colors()` to see all available color.
+#' Can be used to get the hex code of specific colors from the material design
+#' color palette. Use `material_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'

--- a/R/scale_color_material.R
+++ b/R/scale_color_material.R
@@ -1,8 +1,8 @@
 #' Material design color palette
 #'
-#' The palette based on \href{https://www.materialui.co/color}{material design
-#' colors}. Use \code{scale_color_material_d()} for \emph{discrete} categories
-#' and \code{scale_color_material_c()} for a \emph{continuous} scale.
+#' The palette based on [material design
+#' colors](https://www.materialui.co/color). Use `scale_color_material_d()` for *discrete* categories
+#' and `scale_color_material_c()` for a *continuous* scale.
 #'
 #' @inheritParams palette_material
 #' @inheritParams scale_color_flat
@@ -133,7 +133,7 @@ material_colors_list <- c(
 
 #' Extract material design colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the material design color palette. Use \code{material_colors()} to see all available color.
+#' Can be used to get the hex code of specific colors from the material design color palette. Use `material_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'
@@ -173,13 +173,13 @@ material_palettes <- list(
 
 #' Material design color palette
 #'
-#' The palette based on \href{https://www.materialui.co/color}{material design
-#' colors}.
+#' The palette based on [material design
+#' colors](https://www.materialui.co/color).
 #'
 #' @inheritParams palette_flat
 #'
 #' @details This function is usually not called directly, but from within
-#'   \code{\link[=scale_color_material]{scale_color_material()}}.
+#'   [`scale_color_material()`][scale_color_material].
 #'
 #' @export
 palette_material <- function(palette = "contrast", reverse = FALSE, ...) {

--- a/R/scale_color_metro.R
+++ b/R/scale_color_metro.R
@@ -1,9 +1,9 @@
 #' Metro color palette
 #'
-#' The palette based on Metro \href{https://www.materialui.co/metrocolors}{Metro
-#' colors}.
-#' Use \code{scale_color_metro_d} for \emph{discrete} categories and
-#' \code{scale_color_metro_c} for a \emph{continuous} scale.
+#' The palette based on Metro [Metro
+#' colors](https://www.materialui.co/metrocolors).
+#' Use `scale_color_metro_d` for *discrete* categories and
+#' `scale_color_metro_c` for a *continuous* scale.
 #'
 #' @inheritParams palette_metro
 #' @inheritParams scale_color_flat
@@ -129,7 +129,7 @@ metro_colors_list <- c(
 
 #' Extract Metro colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the Metro color palette. Use \code{metro_colors()} to see all available color.
+#' Can be used to get the hex code of specific colors from the Metro color palette. Use `metro_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'
@@ -169,13 +169,13 @@ metro_palettes <- list(
 
 #' Metro color palette
 #'
-#' The palette based on \href{https://www.materialui.co/metrocolors}{Metro
-#' colors}.
+#' The palette based on [Metro
+#' colors](https://www.materialui.co/metrocolors).
 #'
 #' @inheritParams palette_flat
 #'
 #' @details This function is usually not called directly, but from within
-#'   \code{\link[=scale_color_metro]{scale_color_metro()}}.
+#'   [`scale_color_metro()`][scale_color_metro].
 #'
 #' @export
 palette_metro <- function(palette = "complement", reverse = FALSE, ...) {

--- a/R/scale_color_metro.R
+++ b/R/scale_color_metro.R
@@ -129,7 +129,8 @@ metro_colors_list <- c(
 
 #' Extract Metro colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the Metro color palette. Use `metro_colors()` to see all available color.
+#' Can be used to get the hex code of specific colors from the Metro color
+#' palette. Use `metro_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'

--- a/R/scale_color_pizza.R
+++ b/R/scale_color_pizza.R
@@ -3,8 +3,8 @@
 #' Pizza color palette
 #'
 #' The palette based on authentic neapolitan pizzas.
-#' Use \code{scale_color_pizza_d()} for \emph{discrete} categories and
-#' \code{scale_color_pizza_c()} for a \emph{continuous} scale.
+#' Use `scale_color_pizza_d()` for *discrete* categories and
+#' `scale_color_pizza_c()` for a *continuous* scale.
 #'
 #' @inheritParams palette_pizza
 #' @inheritParams scale_color_flat
@@ -152,10 +152,10 @@ pizza_palettes <- list(
 #' @param palette Pizza type. Can be "margherita" (default), "margherita_crust",
 #'  "diavola" or "diavola_crust".
 #' @param reverse Boolean indicating whether the palette should be reversed.
-#' @param ... Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.
+#' @param ... Additional arguments to pass to [`colorRampPalette()`][colorRampPalette].
 #'
 #' @details This function is usually not called directly, but from within
-#'   \code{\link[=scale_color_pizza]{scale_color_pizza()}}.
+#'   [`scale_color_pizza()`][scale_color_pizza].
 #'
 #' @export
 palette_pizza <- function(palette = "margherita", reverse = FALSE, ...) {

--- a/R/scale_color_see.R
+++ b/R/scale_color_see.R
@@ -1,7 +1,7 @@
 #' See color palette
 #'
-#' The See color palette. Use \code{scale_color_see_d()} for \emph{discrete}
-#' categories and \code{scale_color_see_c()} for a \emph{continuous} scale.
+#' The See color palette. Use `scale_color_see_d()` for *discrete*
+#' categories and `scale_color_see_c()` for a *continuous* scale.
 #'
 #' @inheritParams palette_see
 #' @inheritParams scale_color_flat
@@ -157,7 +157,7 @@ see_colors_list <- c(
 #' Extract See colors as hex codes
 #'
 #' Can be used to get the hex code of specific colors from the See color
-#' palette. Use \code{see_colors()} to see all available color.
+#' palette. Use `see_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'
@@ -194,7 +194,7 @@ see_palettes <- list(
 #' @inheritParams palette_flat
 #'
 #' @details This function is usually not called directly, but from within
-#'   \code{\link[=scale_color_see]{scale_color_see()}}.
+#'   [`scale_color_see()`][scale_color_see].
 #'
 #' @export
 palette_see <- function(palette = "contrast", reverse = FALSE, ...) {

--- a/R/scale_color_see.R
+++ b/R/scale_color_see.R
@@ -26,10 +26,9 @@
 #'   scale_color_see_c(palette = "rainbow")
 #' @export
 scale_color_see <- function(palette = "contrast",
-           discrete = TRUE,
-           reverse = FALSE,
-           ...) {
-
+                            discrete = TRUE,
+                            reverse = FALSE,
+                            ...) {
   pal <- palette_see(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -47,26 +46,30 @@ scale_color_see <- function(palette = "contrast",
 #' @rdname scale_color_see
 #' @export
 scale_color_see_d <- function(palette = "contrast",
-           discrete = TRUE,
-           reverse = FALSE,
-           ...) {
-    scale_color_see(palette = palette,
-                    discrete = discrete,
-                    reverse = reverse,
-                    ...)
-  }
+                              discrete = TRUE,
+                              reverse = FALSE,
+                              ...) {
+  scale_color_see(
+    palette = palette,
+    discrete = discrete,
+    reverse = reverse,
+    ...
+  )
+}
 
 #' @rdname scale_color_see
 #' @export
 scale_color_see_c <- function(palette = "contrast",
-           discrete = FALSE,
-           reverse = FALSE,
-           ...) {
-    scale_color_see(palette = palette,
-                    discrete = discrete,
-                    reverse = reverse,
-                    ...)
-  }
+                              discrete = FALSE,
+                              reverse = FALSE,
+                              ...) {
+  scale_color_see(
+    palette = palette,
+    discrete = discrete,
+    reverse = reverse,
+    ...
+  )
+}
 
 #' @rdname scale_color_see
 #' @export
@@ -91,10 +94,9 @@ scale_colour_see_d <- scale_color_see_d
 #' @rdname scale_color_see
 #' @export
 scale_fill_see <- function(palette = "contrast",
-           discrete = TRUE,
-           reverse = FALSE,
-           ...) {
-
+                           discrete = TRUE,
+                           reverse = FALSE,
+                           ...) {
   pal <- palette_see(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -108,26 +110,30 @@ scale_fill_see <- function(palette = "contrast",
 #' @rdname scale_color_see
 #' @export
 scale_fill_see_d <- function(palette = "contrast",
-           discrete = TRUE,
-           reverse = FALSE,
-           ...) {
-    scale_fill_see(palette = palette,
-                   discrete = discrete,
-                   reverse = reverse,
-                   ...)
-  }
+                             discrete = TRUE,
+                             reverse = FALSE,
+                             ...) {
+  scale_fill_see(
+    palette = palette,
+    discrete = discrete,
+    reverse = reverse,
+    ...
+  )
+}
 
 #' @rdname scale_color_see
 #' @export
 scale_fill_see_c <- function(palette = "contrast",
-           discrete = FALSE,
-           reverse = FALSE,
-           ...) {
-    scale_fill_see(palette = palette,
-                   discrete = discrete,
-                   reverse = reverse,
-                   ...)
-  }
+                             discrete = FALSE,
+                             reverse = FALSE,
+                             ...) {
+  scale_fill_see(
+    palette = palette,
+    discrete = discrete,
+    reverse = reverse,
+    ...
+  )
+}
 
 
 

--- a/R/scale_color_social.R
+++ b/R/scale_color_social.R
@@ -1,8 +1,8 @@
 #' Social color palette
 #'
-#' The palette based \href{https://www.materialui.co/socialcolors}{Social colors}.
-#' Use \code{scale_color_social_d} for \emph{discrete} categories and
-#' \code{scale_color_social_c} for a \emph{continuous} scale.
+#' The palette based [Social colors](https://www.materialui.co/socialcolors).
+#' Use `scale_color_social_d` for *discrete* categories and
+#' `scale_color_social_c` for a *continuous* scale.
 #'
 #' @inheritParams palette_social
 #' @inheritParams scale_color_flat
@@ -130,7 +130,7 @@ social_colors_list <- c(
 
 #' Extract Social colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the Social color palette. Use \code{social_colors()} to see all available color.
+#' Can be used to get the hex code of specific colors from the Social color palette. Use `social_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'
@@ -170,12 +170,12 @@ social_palettes <- list(
 
 #' Social color palette
 #'
-#' The palette based \href{https://www.materialui.co/socialcolors}{Social colors}.
+#' The palette based [Social colors](https://www.materialui.co/socialcolors).
 #'
 #' @inheritParams palette_flat
 #'
 #' @details This function is usually not called directly, but from within
-#'   \code{\link[=scale_color_social]{scale_color_social()}}.
+#'   [`scale_color_social()`][scale_color_social].
 #'
 #' @export
 palette_social <- function(palette = "complement", reverse = FALSE, ...) {

--- a/R/scale_color_social.R
+++ b/R/scale_color_social.R
@@ -130,7 +130,8 @@ social_colors_list <- c(
 
 #' Extract Social colors as hex codes
 #'
-#' Can be used to get the hex code of specific colors from the Social color palette. Use `social_colors()` to see all available color.
+#' Can be used to get the hex code of specific colors from the Social color
+#' palette. Use `social_colors()` to see all available color.
 #'
 #' @inheritParams flat_colors
 #'

--- a/R/theme_radar.R
+++ b/R/theme_radar.R
@@ -1,6 +1,7 @@
 #' Themes for radar plots
 #'
-#' `theme_radar()` is a light, clear theme for ggplot radar-plots, while `theme_radar_dark()` is a dark variant of `theme_radar()`.
+#' `theme_radar()` is a light, clear theme for ggplot radar-plots, while
+#' `theme_radar_dark()` is a dark variant of `theme_radar()`.
 #'
 #' @inheritParams theme_modern
 #'

--- a/R/theme_radar.R
+++ b/R/theme_radar.R
@@ -1,10 +1,10 @@
 #' Themes for radar plots
 #'
-#' \code{theme_radar()} is a light, clear theme for ggplot radar-plots, while \code{theme_radar_dark()} is a dark variant of \code{theme_radar()}.
+#' `theme_radar()` is a light, clear theme for ggplot radar-plots, while `theme_radar_dark()` is a dark variant of `theme_radar()`.
 #'
 #' @inheritParams theme_modern
 #'
-#' @seealso \code{\link{coord_radar}}
+#' @seealso [coord_radar()]
 #'
 #' @examples
 #' if (require("ggplot2") && require("dplyr") && require("tidyr")) {

--- a/man/add_plot_attributes.Rd
+++ b/man/add_plot_attributes.Rd
@@ -10,7 +10,8 @@ add_plot_attributes(x)
 \item{x}{An object.}
 }
 \description{
-The \link{data_plot} function usually stores information (such as title, axes labels etc.) as attributes. This function adds those information to the plot.
+The \link{data_plot} function usually stores information (such as title, axes
+labels etc.) as attributes. This function adds those information to the plot.
 }
 \examples{
 \dontrun{

--- a/man/data_plot.Rd
+++ b/man/data_plot.Rd
@@ -16,40 +16,40 @@ statistical model or such.}
 }
 \description{
 \code{data_plot()} attempts to extract and transform an object
-  to be further plotted, while \code{plot()} tries to visualize results of
-  functions from different packages of the
-  \href{https://github.com/easystats}{easystats-project}. See the
-  documentation for your object's class:
+to be further plotted, while \code{plot()} tries to visualize results of
+functions from different packages of the
+\href{https://github.com/easystats}{easystats-project}. See the
+documentation for your object's class:
 \itemize{
- \item{\link[=plot.see_bayesfactor_models]{bayestestR::bayesfactor_models()}}
- \item{\link[=plot.see_bayesfactor_parameters]{bayestestR::bayesfactor_parameters()}}
- \item{\link[=plot.see_equivalence_test]{bayestestR::equivalence_test()}}
- \item{\link[=plot.see_estimate_density]{bayestestR::estimate_density()}}
- \item{\link[=plot.see_hdi]{bayestestR::hdi()}}
- \item{\link[=plot.see_p_direction]{bayestestR::p_direction()}}
- \item{\link[=plot.see_p_significance]{bayestestR::p_significance()}}
- \item{\link[=plot.see_si]{bayestestR::si()}}
- \item{\link[=plot.see_easycormatrix]{correlation::correlation()}}
- \item{\link[=plot.see_easycorrelation]{correlation::correlation()} (Gaussian Graphical Models)}
- \item{\link[=plot.see_effectsize_table]{effectsize::effectsize()}}
- \item{\link[=plot.see_estimate_contrasts]{modelbased::estimate_contrasts()}}
- \item{\link[=plot.see_cluster_analysis]{parameters::cluster_analysis()}}
- \item{\link[=plot.see_compare_parameters]{parameters::compare_parameters()}}
- \item{\link[=plot.see_parameters_distribution]{parameters::describe_distribution()}}
- \item{\link[=plot.see_parameters_model]{parameters::model_parameters()}}
- \item{\link[=plot.see_parameters_pca]{parameters::principal_components()}}
- \item{\link[=plot.see_n_factors]{parameters::n_clusters()}}
- \item{\link[=plot.see_n_factors]{parameters::n_factors()}}
- \item{\link[=plot.see_parameters_simulate]{parameters::simulate_parameters()}}
- \item{\link[=plot.see_check_collinearity]{performance::check_collinearity()}}
- \item{\link[=plot.see_check_heteroscedasticity]{performance::check_heteroscedasticity()}}
- \item{\link[=plot.see_check_homogeneity]{performance::check_homogeneity()}}
- \item{\link[=plot.see_check_normality]{performance::check_normality()}}
- \item{\link[=plot.see_check_outliers]{performance::check_outliers()}}
- \item{\link[=plot.see_compare_performance]{performance::compare_performance()}}
- \item{\link[=plot.see_performance_roc]{performance::performance_roc()}}
- \item{\link[=plot.see_performance_pp_check]{performance::pp_check()}}
- }
+\item{\link[=plot.see_bayesfactor_models]{bayestestR::bayesfactor_models()}}
+\item{\link[=plot.see_bayesfactor_parameters]{bayestestR::bayesfactor_parameters()}}
+\item{\link[=plot.see_equivalence_test]{bayestestR::equivalence_test()}}
+\item{\link[=plot.see_estimate_density]{bayestestR::estimate_density()}}
+\item{\link[=plot.see_hdi]{bayestestR::hdi()}}
+\item{\link[=plot.see_p_direction]{bayestestR::p_direction()}}
+\item{\link[=plot.see_p_significance]{bayestestR::p_significance()}}
+\item{\link[=plot.see_si]{bayestestR::si()}}
+\item{\link[=plot.see_easycormatrix]{correlation::correlation()}}
+\item{\link[=plot.see_easycorrelation]{correlation::correlation()} (Gaussian Graphical Models)}
+\item{\link[=plot.see_effectsize_table]{effectsize::effectsize()}}
+\item{\link[=plot.see_estimate_contrasts]{modelbased::estimate_contrasts()}}
+\item{\link[=plot.see_cluster_analysis]{parameters::cluster_analysis()}}
+\item{\link[=plot.see_compare_parameters]{parameters::compare_parameters()}}
+\item{\link[=plot.see_parameters_distribution]{parameters::describe_distribution()}}
+\item{\link[=plot.see_parameters_model]{parameters::model_parameters()}}
+\item{\link[=plot.see_parameters_pca]{parameters::principal_components()}}
+\item{\link[=plot.see_n_factors]{parameters::n_clusters()}}
+\item{\link[=plot.see_n_factors]{parameters::n_factors()}}
+\item{\link[=plot.see_parameters_simulate]{parameters::simulate_parameters()}}
+\item{\link[=plot.see_check_collinearity]{performance::check_collinearity()}}
+\item{\link[=plot.see_check_heteroscedasticity]{performance::check_heteroscedasticity()}}
+\item{\link[=plot.see_check_homogeneity]{performance::check_homogeneity()}}
+\item{\link[=plot.see_check_normality]{performance::check_normality()}}
+\item{\link[=plot.see_check_outliers]{performance::check_outliers()}}
+\item{\link[=plot.see_compare_performance]{performance::compare_performance()}}
+\item{\link[=plot.see_performance_roc]{performance::performance_roc()}}
+\item{\link[=plot.see_performance_pp_check]{performance::pp_check()}}
+}
 }
 \details{
 \code{data_plot()} is in most situation not needed when the purpose
@@ -61,7 +61,7 @@ the data or model for plotting can't be retrieved via \code{data_plot()}. In
 such cases, \code{plot()} gives an error and asks for providing data or models.
 \cr \cr
 Most \code{plot()}-functions work out-of-the-box, i.e. you don't need to do
-much more than calling \code{plot(<object>)} (see 'Examples'). Some plot-functions
+much more than calling \verb{plot(<object>)} (see 'Examples'). Some plot-functions
 allow to specify arguments to modify the transparency or color of geoms, these
 are shown in the 'Usage' section.
 }

--- a/man/flat_colors.Rd
+++ b/man/flat_colors.Rd
@@ -13,7 +13,8 @@ flat_colors(...)
 A character vector with color-codes.
 }
 \description{
-Can be used to get the hex code of specific colors from the Flat UI color palette. Use \code{flat_colors()} to see all available color.
+Can be used to get the hex code of specific colors from the Flat UI color
+palette. Use \code{flat_colors()} to see all available color.
 }
 \examples{
 flat_colors()

--- a/man/geom_from_list.Rd
+++ b/man/geom_from_list.Rd
@@ -11,10 +11,9 @@ geoms_from_list(x, ...)
 }
 \arguments{
 \item{x}{A list containing a geom type (e.g., \code{geom = "point"}), a list
-of aesthetics (as characters; e.g., \code{aes = list(x = "mpg", y =
-"wt")}), some data (e.g., \code{data = mtcars}) and some other parameters.
+of aesthetics (as characters; e.g., \code{aes = list(x = "mpg", y = "wt")}), some data (e.g., \code{data = mtcars}) and some other parameters.
 For \code{geoms_from_list()} ("geoms" with an "s"), the input must be a
-list of lists, ideally named \code{"l1", "l2", "l3"}, etc.}
+list of lists, ideally named \verb{"l1", "l2", "l3"}, etc.}
 
 \item{...}{Additional arguments passed to \code{ggplot2::layer()}.}
 }

--- a/man/geom_point2.Rd
+++ b/man/geom_point2.Rd
@@ -29,10 +29,10 @@ geom_pointrange_borderless(...)
 }
 \arguments{
 \item{...}{Other arguments to be passed to
-\code{\link[ggplot2:geom_point]{geom_point}},
-\code{\link[ggplot2:geom_jitter]{geom_jitter}},
-\code{\link[ggplot2:geom_pointrange]{geom_pointrange}}, or
-\code{\link[ggplot2:geom_count]{ggplot2::geom_count}}.}
+\code{\link[ggplot2:geom_point]{ggplot2::geom_point()}},
+\code{\link[ggplot2:geom_jitter]{ggplot2::geom_jitter()}},
+\code{\link[ggplot2:geom_linerange]{ggplot2::geom_pointrange()}}, or
+\code{\link[ggplot2:geom_count]{ggplot2::geom_count()}}.}
 
 \item{stroke}{Stroke thickness.}
 
@@ -46,7 +46,7 @@ strokes (borders, contours) by default.
 }
 \note{
 The color aesthetics for \code{geom_point_borderless()} is
-  \code{"fill"}, not \code{color}. See 'Examples'.
+\code{"fill"}, not \code{color}. See 'Examples'.
 }
 \examples{
 library(ggplot2)

--- a/man/geom_violinhalf.Rd
+++ b/man/geom_violinhalf.Rd
@@ -77,5 +77,4 @@ ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_violinhalf() +
   theme_modern() +
   scale_fill_material_d()
-
 }

--- a/man/material_colors.Rd
+++ b/man/material_colors.Rd
@@ -13,7 +13,8 @@ material_colors(...)
 A character vector with color-codes.
 }
 \description{
-Can be used to get the hex code of specific colors from the material design color palette. Use \code{material_colors()} to see all available color.
+Can be used to get the hex code of specific colors from the material design
+color palette. Use \code{material_colors()} to see all available color.
 }
 \examples{
 material_colors()

--- a/man/metro_colors.Rd
+++ b/man/metro_colors.Rd
@@ -13,7 +13,8 @@ metro_colors(...)
 A character vector with color-codes.
 }
 \description{
-Can be used to get the hex code of specific colors from the Metro color palette. Use \code{metro_colors()} to see all available color.
+Can be used to get the hex code of specific colors from the Metro color
+palette. Use \code{metro_colors()} to see all available color.
 }
 \examples{
 metro_colors()

--- a/man/palette_bluebrown.Rd
+++ b/man/palette_bluebrown.Rd
@@ -20,5 +20,5 @@ The palette based on blue-brown colors.
 }
 \details{
 This function is usually not called directly, but from within
-  \code{\link[=scale_color_bluebrown]{scale_color_bluebrown()}}.
+\code{\link[=scale_color_bluebrown]{scale_color_bluebrown()}}.
 }

--- a/man/palette_flat.Rd
+++ b/man/palette_flat.Rd
@@ -20,5 +20,5 @@ The palette based on \href{https://www.materialui.co/flatuicolors}{Flat UI}.
 }
 \details{
 This function is usually not called directly, but from within
-  \code{\link[=scale_color_flat]{scale_color_flat()}}.
+\code{\link[=scale_color_flat]{scale_color_flat()}}.
 }

--- a/man/palette_material.Rd
+++ b/man/palette_material.Rd
@@ -16,10 +16,9 @@ be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The palette based on \href{https://www.materialui.co/color}{material design
-colors}.
+The palette based on \href{https://www.materialui.co/color}{material design colors}.
 }
 \details{
 This function is usually not called directly, but from within
-  \code{\link[=scale_color_material]{scale_color_material()}}.
+\code{\link[=scale_color_material]{scale_color_material()}}.
 }

--- a/man/palette_metro.Rd
+++ b/man/palette_metro.Rd
@@ -16,10 +16,9 @@ be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The palette based on \href{https://www.materialui.co/metrocolors}{Metro
-colors}.
+The palette based on \href{https://www.materialui.co/metrocolors}{Metro colors}.
 }
 \details{
 This function is usually not called directly, but from within
-  \code{\link[=scale_color_metro]{scale_color_metro()}}.
+\code{\link[=scale_color_metro]{scale_color_metro()}}.
 }

--- a/man/palette_pizza.Rd
+++ b/man/palette_pizza.Rd
@@ -19,5 +19,5 @@ The palette based on authentic neapolitan pizzas.
 }
 \details{
 This function is usually not called directly, but from within
-  \code{\link[=scale_color_pizza]{scale_color_pizza()}}.
+\code{\link[=scale_color_pizza]{scale_color_pizza()}}.
 }

--- a/man/palette_see.Rd
+++ b/man/palette_see.Rd
@@ -20,5 +20,5 @@ See design color palette
 }
 \details{
 This function is usually not called directly, but from within
-  \code{\link[=scale_color_see]{scale_color_see()}}.
+\code{\link[=scale_color_see]{scale_color_see()}}.
 }

--- a/man/palette_social.Rd
+++ b/man/palette_social.Rd
@@ -20,5 +20,5 @@ The palette based \href{https://www.materialui.co/socialcolors}{Social colors}.
 }
 \details{
 This function is usually not called directly, but from within
-  \code{\link[=scale_color_social]{scale_color_social()}}.
+\code{\link[=scale_color_social]{scale_color_social()}}.
 }

--- a/man/plot.see_bayesfactor_models.Rd
+++ b/man/plot.see_bayesfactor_models.Rd
@@ -23,7 +23,8 @@
 
 \item{sort}{\describe{
 \item{\emph{Plotting model parameters}}{
-If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
+If \code{NULL}, coefficients are plotted in the order as they appear in the
+summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
 }
 \item{\emph{Plotting Bayes factors}}{
 Sort pie-slices by posterior probability (descending)?
@@ -33,9 +34,9 @@ Sort pie-slices by posterior probability (descending)?
 \item{log}{Show log-transformed Bayes factors.}
 
 \item{prior_odds}{optional vector of prior odds for the models. See
-\code{BayesFactor::priorOdds}. As the size of the pizza slices corresponds
-to posterior probability (which is a function of prior probability and the BF),
-custom \code{prior_odds} will change the slices' size.}
+\code{BayesFactor::priorOdds}. As the size of the pizza slices corresponds to
+posterior probability (which is a function of prior probability and the
+BF), custom \code{prior_odds} will change the slices' size.}
 
 \item{...}{Arguments passed to or from other methods.}
 }

--- a/man/plot.see_bayesfactor_models.Rd
+++ b/man/plot.see_bayesfactor_models.Rd
@@ -22,12 +22,12 @@
 \item{value}{What value to display.}
 
 \item{sort}{\describe{
-  \item{\emph{Plotting model parameters}}{
-  If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
-  }
-  \item{\emph{Plotting Bayes factors}}{
-  Sort pie-slices by posterior probability (descending)?
-  }
+\item{\emph{Plotting model parameters}}{
+If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
+}
+\item{\emph{Plotting Bayes factors}}{
+Sort pie-slices by posterior probability (descending)?
+}
 }}
 
 \item{log}{Show log-transformed Bayes factors.}

--- a/man/plot.see_compare_parameters.Rd
+++ b/man/plot.see_compare_parameters.Rd
@@ -32,7 +32,8 @@ between geoms.}
 
 \item{sort}{\describe{
 \item{\emph{Plotting model parameters}}{
-If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
+If \code{NULL}, coefficients are plotted in the order as they appear in the
+summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
 }
 \item{\emph{Plotting Bayes factors}}{
 Sort pie-slices by posterior probability (descending)?

--- a/man/plot.see_compare_parameters.Rd
+++ b/man/plot.see_compare_parameters.Rd
@@ -31,12 +31,12 @@ posterior distributions for other parameters are hardly visible.}
 between geoms.}
 
 \item{sort}{\describe{
-  \item{\emph{Plotting model parameters}}{
-  If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
-  }
-  \item{\emph{Plotting Bayes factors}}{
-  Sort pie-slices by posterior probability (descending)?
-  }
+\item{\emph{Plotting model parameters}}{
+If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
+}
+\item{\emph{Plotting Bayes factors}}{
+Sort pie-slices by posterior probability (descending)?
+}
 }}
 
 \item{n_columns}{For models with multiple components (like fixed and random,

--- a/man/plot.see_estimate_density.Rd
+++ b/man/plot.see_estimate_density.Rd
@@ -35,7 +35,7 @@ count and zero-inflated), defines the number of columns for the
 panel-layout. If \code{NULL}, a single, integrated plot is shown.}
 
 \item{priors}{Logical, if \code{TRUE}, prior distributions are simulated
-(using \code{\link[bayestestR:simulate_prior]{simulate_prior()}}) and added
+(using \code{\link[bayestestR:simulate_prior]{bayestestR::simulate_prior()}}) and added
 to the plot.}
 
 \item{priors_alpha}{Alpha value of the prior distributions.}

--- a/man/plot.see_p_direction.Rd
+++ b/man/plot.see_p_direction.Rd
@@ -26,7 +26,7 @@ has a posterior distribution on a very different location, so density curves of
 posterior distributions for other parameters are hardly visible.}
 
 \item{priors}{Logical, if \code{TRUE}, prior distributions are simulated
-(using \code{\link[bayestestR:simulate_prior]{simulate_prior()}}) and added
+(using \code{\link[bayestestR:simulate_prior]{bayestestR::simulate_prior()}}) and added
 to the plot.}
 
 \item{priors_alpha}{Alpha value of the prior distributions.}

--- a/man/plot.see_p_significance.Rd
+++ b/man/plot.see_p_significance.Rd
@@ -26,7 +26,7 @@ has a posterior distribution on a very different location, so density curves of
 posterior distributions for other parameters are hardly visible.}
 
 \item{priors}{Logical, if \code{TRUE}, prior distributions are simulated
-(using \code{\link[bayestestR:simulate_prior]{simulate_prior()}}) and added
+(using \code{\link[bayestestR:simulate_prior]{bayestestR::simulate_prior()}}) and added
 to the plot.}
 
 \item{priors_alpha}{Alpha value of the prior distributions.}

--- a/man/plot.see_parameters_brms_meta.Rd
+++ b/man/plot.see_parameters_brms_meta.Rd
@@ -47,15 +47,13 @@ function when used with brms-meta-analysis models.
 }
 \details{
 \subsection{Colors of density areas and errorbars}{
-  To change the colors of the density areas, use \code{scale_fill_manual()}
-  with named color-values, e.g. \code{scale_fill_manual(values = c("Study" =
-  "blue", "Overall" = "green"))}.
-  To change the color of the error bars, use \code{scale_color_manual(values
-  = c("Errorbar" = "red"))}.
+To change the colors of the density areas, use \code{scale_fill_manual()}
+with named color-values, e.g. \code{scale_fill_manual(values = c("Study" = "blue", "Overall" = "green"))}.
+To change the color of the error bars, use \code{scale_color_manual(values = c("Errorbar" = "red"))}.
 }
 \subsection{Show or hide estimates and CI}{
-  Use \code{size_text = NULL} or \code{size_text = NA} to hide the textual
-  output of estimates and credible intervals.
+Use \code{size_text = NULL} or \code{size_text = NA} to hide the textual
+output of estimates and credible intervals.
 }
 }
 \examples{

--- a/man/plot.see_parameters_model.Rd
+++ b/man/plot.see_parameters_model.Rd
@@ -44,7 +44,8 @@ posterior distributions for other parameters are hardly visible.}
 
 \item{sort}{\describe{
 \item{\emph{Plotting model parameters}}{
-If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
+If \code{NULL}, coefficients are plotted in the order as they appear in the
+summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
 }
 \item{\emph{Plotting Bayes factors}}{
 Sort pie-slices by posterior probability (descending)?
@@ -55,9 +56,11 @@ Sort pie-slices by posterior probability (descending)?
 count and zero-inflated), defines the number of columns for the
 panel-layout. If \code{NULL}, a single, integrated plot is shown.}
 
-\item{type}{Indicating the type of plot. Only applies for model parameters from meta-analysis objects (e.g. \pkg{metafor}).}
+\item{type}{Indicating the type of plot. Only applies for model parameters
+from meta-analysis objects (e.g. \pkg{metafor}).}
 
-\item{weight_points}{Logical, if \code{TRUE}, for meta-analysis objects, point size will be adjusted according to the study-weights.}
+\item{weight_points}{Logical, if \code{TRUE}, for meta-analysis objects, point
+size will be adjusted according to the study-weights.}
 
 \item{...}{Arguments passed to or from other methods.}
 

--- a/man/plot.see_parameters_model.Rd
+++ b/man/plot.see_parameters_model.Rd
@@ -43,12 +43,12 @@ posterior distributions for other parameters are hardly visible.}
 \item{size_text}{Size of text labels.}
 
 \item{sort}{\describe{
-  \item{\emph{Plotting model parameters}}{
-  If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
-  }
-  \item{\emph{Plotting Bayes factors}}{
-  Sort pie-slices by posterior probability (descending)?
-  }
+\item{\emph{Plotting model parameters}}{
+If \code{NULL}, coefficients are plotted in the order as they appear in the summary. Use \code{sort = "ascending"} (or \code{sort = TRUE})) resp. \code{sort = "descending"} to sort coefficients in ascending or descending order.
+}
+\item{\emph{Plotting Bayes factors}}{
+Sort pie-slices by posterior probability (descending)?
+}
 }}
 
 \item{n_columns}{For models with multiple components (like fixed and random,

--- a/man/plot.see_point_estimate.Rd
+++ b/man/plot.see_point_estimate.Rd
@@ -41,7 +41,7 @@ has a posterior distribution on a very different location, so density curves of
 posterior distributions for other parameters are hardly visible.}
 
 \item{priors}{Logical, if \code{TRUE}, prior distributions are simulated
-(using \code{\link[bayestestR:simulate_prior]{simulate_prior()}}) and added
+(using \code{\link[bayestestR:simulate_prior]{bayestestR::simulate_prior()}}) and added
 to the plot.}
 
 \item{priors_alpha}{Alpha value of the prior distributions.}

--- a/man/plot.see_si.Rd
+++ b/man/plot.see_si.Rd
@@ -27,7 +27,7 @@ posterior distributions for other parameters are hardly visible.}
 
 \item{support_only}{Plot only the support data, or show the "raw" prior and
 posterior distributions? Only applies when plotting
-\code{\link[bayestestR]{si}}.}
+\code{\link[bayestestR:si]{bayestestR::si()}}.}
 
 \item{...}{Arguments passed to or from other methods.}
 }

--- a/man/plots.Rd
+++ b/man/plots.Rd
@@ -57,8 +57,7 @@ background, are used.}
 \description{
 A wrapper around \emph{patchwork} to plot multiple figures side by side on
 the same page. See
-\href{https://patchwork.data-imaginist.com/articles/patchwork.html}{the
-\emph{patchwork} documentation} for more advanced control of plot layouts.
+\href{https://patchwork.data-imaginist.com/articles/patchwork.html}{the \emph{patchwork} documentation} for more advanced control of plot layouts.
 }
 \examples{
 library(ggplot2)

--- a/man/scale_color_material.Rd
+++ b/man/scale_color_material.Rd
@@ -87,8 +87,7 @@ be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The palette based on \href{https://www.materialui.co/color}{material design
-colors}. Use \code{scale_color_material_d()} for \emph{discrete} categories
+The palette based on \href{https://www.materialui.co/color}{material design colors}. Use \code{scale_color_material_d()} for \emph{discrete} categories
 and \code{scale_color_material_c()} for a \emph{continuous} scale.
 }
 \examples{

--- a/man/scale_color_material.Rd
+++ b/man/scale_color_material.Rd
@@ -87,8 +87,9 @@ be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The palette based on \href{https://www.materialui.co/color}{material design colors}. Use \code{scale_color_material_d()} for \emph{discrete} categories
-and \code{scale_color_material_c()} for a \emph{continuous} scale.
+The palette based on \href{https://www.materialui.co/color}{material design colors}. Use \code{scale_color_material_d()} for
+\emph{discrete} categories and \code{scale_color_material_c()} for a \emph{continuous}
+scale.
 }
 \examples{
 library(ggplot2)

--- a/man/scale_color_metro.Rd
+++ b/man/scale_color_metro.Rd
@@ -82,8 +82,7 @@ be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The palette based on Metro \href{https://www.materialui.co/metrocolors}{Metro
-colors}.
+The palette based on Metro \href{https://www.materialui.co/metrocolors}{Metro colors}.
 Use \code{scale_color_metro_d} for \emph{discrete} categories and
 \code{scale_color_metro_c} for a \emph{continuous} scale.
 }

--- a/man/social_colors.Rd
+++ b/man/social_colors.Rd
@@ -13,7 +13,8 @@ social_colors(...)
 A character vector with color-codes.
 }
 \description{
-Can be used to get the hex code of specific colors from the Social color palette. Use \code{social_colors()} to see all available color.
+Can be used to get the hex code of specific colors from the Social color
+palette. Use \code{social_colors()} to see all available color.
 }
 \examples{
 social_colors()

--- a/man/theme_radar.Rd
+++ b/man/theme_radar.Rd
@@ -77,7 +77,8 @@ theme_radar_dark(
 \item{tags.face}{Tags font face ("plain", "italic", "bold", "bold.italic").}
 }
 \description{
-\code{theme_radar()} is a light, clear theme for ggplot radar-plots, while \code{theme_radar_dark()} is a dark variant of \code{theme_radar()}.
+\code{theme_radar()} is a light, clear theme for ggplot radar-plots, while
+\code{theme_radar_dark()} is a dark variant of \code{theme_radar()}.
 }
 \examples{
 if (require("ggplot2") && require("dplyr") && require("tidyr")) {

--- a/man/theme_radar.Rd
+++ b/man/theme_radar.Rd
@@ -100,5 +100,5 @@ if (require("ggplot2") && require("dplyr") && require("tidyr")) {
 }
 }
 \seealso{
-\code{\link{coord_radar}}
+\code{\link[=coord_radar]{coord_radar()}}
 }


### PR DESCRIPTION
I am going through the changes.

Unfortunately, `roxygen2md` can't handle `itemize{}` (cf. https://github.com/r-lib/roxygen2md/issues/17), so will need to change this manually 😢 

This is **not** a problem, though, since `roxygen2md` will leave these items unaltered and so the `.Rd` files still look the same.