### PR TITLE
Add flip parameter to `geom_violinhalf()`

### DIFF
--- a/R/geom_violinhalf.R
+++ b/R/geom_violinhalf.R
@@ -12,6 +12,13 @@
 #'   geom_violinhalf() +
 #'   theme_modern() +
 #'   scale_fill_material_d()
+#'
+#' # To flip the half-violin, use `flip = TRUE`:
+#' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
+#'   geom_violinhalf(flip = TRUE) +
+#'   theme_modern() +
+#'   scale_fill_material_d()
+#'
 #' @import ggplot2
 #' @export
 geom_violinhalf <- function(mapping = NULL,

--- a/R/geom_violinhalf.R
+++ b/R/geom_violinhalf.R
@@ -51,47 +51,52 @@ geom_violinhalf <- function(mapping = NULL,
 #' @importFrom rlang `%||%`
 #' @keywords internal
 GeomViolinHalf <- ggproto("GeomViolinHalf", Geom,
-  setup_data = function(data, params) {
-    data$width <- data$width %||% params$width %||% (resolution(data$x, FALSE) * 0.9)
+                          extra_params = c("na.rm", "flip"),
+                          setup_data = function(data, params) {
+                            data$width <- data$width %||% params$width %||% (resolution(data$x, FALSE) * 0.9)
 
-    # ymin, ymax, xmin, and xmax define the bounding rectangle for each group
-    data <- do.call(rbind, lapply(split(data, data$group), function(.group) {
-      .group$ymin <- min(.group$y)
-      .group$ymax <- max(.group$y)
-      .group$xmin <- .group$x
-      .group$xmax <- .group$x + .group$width / 2
-      .group
-    }))
-  },
-  draw_group = function(data, panel_scales, coord) {
-    # Find the points for the line to go all the way around
-    data$xminv <- data$x
-    data$xmaxv <- data$x + data$violinwidth * (data$xmax - data$x)
+                            # ymin, ymax, xmin, and xmax define the bounding rectangle for each group
+                            data <- do.call(rbind, lapply(split(data, data$group), function(.group) {
+                              .group$ymin <- min(.group$y)
+                              .group$ymax <- max(.group$y)
+                              .group$xmin <- .group$x
+                              .group$xmax <- .group$x + .group$width / 2
+                              .group
+                            }))
+                          },
+                          draw_group = function(data, panel_scales, coord, flip = FALSE) {
+                            # Find the points for the line to go all the way around
+                            data$xminv <- data$x
+                            if (flip) {
+                              data$xmaxv <- data$x - data$violinwidth * (data$xmax - data$x)
+                            } else {
+                              data$xmaxv <- data$x + data$violinwidth * (data$xmax - data$x)
+                            }
 
-    # Make sure it's sorted properly to draw the outline
-    mindata <- maxdata <- data
-    mindata$x <- mindata$xminv
-    mindata <- mindata[order(mindata$y), , drop = FALSE]
-    maxdata$x <- maxdata$xmaxv
-    maxdata <- maxdata[order(maxdata$y, decreasing = TRUE), , drop = FALSE]
-    newdata <- rbind(mindata, maxdata)
+                            # Make sure it's sorted properly to draw the outline
+                            mindata <- maxdata <- data
+                            mindata$x <- mindata$xminv
+                            mindata <- mindata[order(mindata$y), , drop = FALSE]
+                            maxdata$x <- maxdata$xmaxv
+                            maxdata <- maxdata[order(maxdata$y, decreasing = TRUE), , drop = FALSE]
+                            newdata <- rbind(mindata, maxdata)
 
-    # Close the polygon: set first and last point the same
-    # Needed for coord_polar and such
-    newdata <- rbind(newdata, newdata[1, ])
+                            # Close the polygon: set first and last point the same
+                            # Needed for coord_polar and such
+                            newdata <- rbind(newdata, newdata[1, ])
 
-    .grobName("geom_violinhalf", GeomPolygon$draw_panel(newdata, panel_scales, coord))
-  },
-  draw_key = draw_key_polygon,
-  default_aes = aes(
-    weight = 1,
-    colour = "grey20",
-    fill = "white",
-    size = 0.5,
-    alpha = NA,
-    linetype = "solid"
-  ),
-  required_aes = c("x", "y")
+                            .grobName("geom_violinhalf", GeomPolygon$draw_panel(newdata, panel_scales, coord))
+                          },
+                          draw_key = draw_key_polygon,
+                          default_aes = aes(
+                            weight = 1,
+                            colour = "grey20",
+                            fill = "white",
+                            size = 0.5,
+                            alpha = NA,
+                            linetype = "solid"
+                          ),
+                          required_aes = c("x", "y")
 )
 
 #' @keywords internal

--- a/man/geom_violinhalf.Rd
+++ b/man/geom_violinhalf.Rd
@@ -10,6 +10,7 @@ geom_violinhalf(
   stat = "ydensity",
   position = "dodge",
   trim = TRUE,
+  flip = FALSE,
   scale = c("area", "count", "width"),
   show.legend = NA,
   inherit.aes = TRUE,
@@ -46,6 +47,12 @@ a call to a position adjustment function.}
 \item{trim}{If \code{TRUE} (default), trim the tails of the violins
 to the range of the data. If \code{FALSE}, don't trim the tails.}
 
+\item{flip}{Should the half-violin plot switch directions? By default, this
+is \code{FALSE} and all half-violin geoms will have the flat-side on facing
+leftward. If \code{flip = TRUE}, then all flat-sides will face rightward.
+Optionally, a numeric vector can be supplied indicating which specific
+geoms should be flipped. See examples for more details.}
+
 \item{scale}{if "area" (default), all violins have the same area (before trimming
 the tails). If "count", areas are scaled proportionally to the number of
 observations. If "width", all violins have the same maximum width.}
@@ -78,10 +85,18 @@ ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   theme_modern() +
   scale_fill_material_d()
 
-# To flip the half-violin, use `flip = TRUE`:
+# To flip all half-violin geoms, use `flip = TRUE`:
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_violinhalf(flip = TRUE) +
   theme_modern() +
   scale_fill_material_d()
+
+# To flip the half-violin geoms for the first and third groups only
+# by passing a numeric vector
+ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
+  geom_violinhalf(flip = c(1,3)) +
+  theme_modern() +
+  scale_fill_material_d()
+
 
 }

--- a/man/geom_violinhalf.Rd
+++ b/man/geom_violinhalf.Rd
@@ -77,4 +77,11 @@ ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_violinhalf() +
   theme_modern() +
   scale_fill_material_d()
+
+# To flip the half-violin, use `flip = TRUE`:
+ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
+  geom_violinhalf(flip = TRUE) +
+  theme_modern() +
+  scale_fill_material_d()
+
 }


### PR DESCRIPTION
Hi! Thanks for creating such a great package! 

I recently had a plot where I wanted a half-violin but facing the other direction and think others may find it useful, too. In this PR I add a commit allowing people to pass in a `flip` parameter into `geom_violinhalf()`. 

By default it is `FALSE` and the flat-side of the violin will be on the left (current behavior). If `flip = TRUE`, then the direction of all half violins will switch and the flat-side will be on the right.

``` r
# Current (and default) behavior
ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
  geom_violinhalf() +
  theme_modern() +
  scale_fill_material_d()
```

![](https://i.imgur.com/DHKcSfq.png)

``` r
# To flip the half-violin, use `flip = TRUE`:
ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
  geom_violinhalf(flip = TRUE) +
  theme_modern() +
  scale_fill_material_d()
```
![Screen Shot 2021-08-06 at 5 28 59 PM](https://user-images.githubusercontent.com/51417262/128572893-4c1dc946-01e1-4aad-838a-06f6d9dab683.png)
