### PR TITLE
Simplify package title

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,6 @@
 Type: Package
 Package: see
-Title: Visualisation Toolbox for 'easystats' and Extra Geoms, Themes and
-    Color Palettes for 'ggplot2'
+Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
 Version: 0.7.0.1
 Authors@R: 
     c(person(given = "Daniel",


### PR DESCRIPTION
I think this is clearer and shortens package citations. Don't think this is likely to cause much issues in terms of citation tracking. Thoughts?