### PR TITLE
Robust patchwork printing

### DIFF
--- a/R/plot.check_model.R
+++ b/R/plot.check_model.R
@@ -163,7 +163,9 @@ plot.see_check_model <- function(x,
   }
 
   if (panel) {
-    plots(p, n_columns = 2)
+    pw <- plots(p, n_columns = 2)
+    .safe_print_plots(pw)
+    invisible(pw)
   } else {
     return(p)
   }

--- a/R/plot.visualisation_recipe.R
+++ b/R/plot.visualisation_recipe.R
@@ -25,5 +25,7 @@ plot.see_visualisation_recipes <- function(x, ...) {
   for (i in names(x)) {
     the_plots[[i]] <- plot(x[[i]])
   }
-  plots(the_plots, ...)
+  pw <- plots(the_plots, ...)
+  .safe_print_plots(pw)
+  invisible(pw)
 }

--- a/R/plots.R
+++ b/R/plots.R
@@ -93,3 +93,14 @@ plots <- function(...,
 
   return(pw)
 }
+
+.safe_print_plots <- function(pw) {
+  pw_drawn <- tryCatch(print(pw), error = function(e) e)
+  if (inherits(pw_drawn, "simpleError")) {
+    if (Sys.getenv("RSTUDIO") == "1") {
+      stop("The RStudio 'Plots' window is too small to show this set of plots.\n Please make the window larger.", call. = FALSE)
+    } else {
+      stop("The viewport is too small to show this set of plots.\n Please make it larger.", call. = FALSE)
+    }
+  }
+}


### PR DESCRIPTION
Make check_model and visualisation_recipe plotting robust to {grid} viewport errors when the RStudio Plots pane is too small.

We can't do anything about making the plot show, but we can give a more useful error message. I submitted a PR to {patchwork}, but we can use it here in the meantime.

@IndrajeetPatil could be useful for {modelsummary}