### PR TITLE
Align labels between plot() and print()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.7.5.3
+Version: 0.7.5.4
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
   for GLMs. Instead, it now shows a half-normal QQ plot of the absolute value
   of the standardized deviance residuals.
 
+* `plot()` for `parameters::equivalence_test()` now aligns the labelling with
+  the `print()` method. Hence, the legend title is no longer labelled
+  `"Decision on H0"`, but rather `"Equivalence"`, to emphasize that we can
+  assume practical equivalence for effects, but that we cannot accept the H0
+  (in a frequentist framework).
+
 ## Bug fixes
 
 * Fixed issue with duplicated legend in the `plot()` method for

--- a/R/plot.equivalence_test.R
+++ b/R/plot.equivalence_test.R
@@ -23,7 +23,7 @@ plot.see_equivalence_test <- function(x,
   model_name <- attr(x, "object_name", exact = TRUE)
 
   if (is.null(model_name)) {
-    warning("plot() only works for equivalence_test() with model-objects.", call. = FALSE)
+    insight::format_alert("`plot()` only works for `equivalence_test()` with model-objects.")
     return(x)
   }
 
@@ -39,7 +39,7 @@ plot.see_equivalence_test <- function(x,
   )
 
   if (is.null(model)) {
-    warning(sprintf("Can't find object '%s'.", model_name), call. = FALSE)
+    insight::format_alert(sprintf("Can't find object '%s'.", model_name))
     return(x)
   }
 
@@ -348,7 +348,7 @@ plot.see_equivalence_test_lm <- function(x,
   model_name <- attr(x, "object_name", exact = TRUE)
 
   if (is.null(model_name)) {
-    insight::format_warning("plot() only works for equivalence_test() with model-objects.")
+    insight::format_alert("`plot()` only works for `equivalence_test()` with model-objects.")
     return(x)
   }
 
@@ -364,7 +364,7 @@ plot.see_equivalence_test_lm <- function(x,
   )
 
   if (is.null(model)) {
-    insight::format_warning(sprintf("Can't find object '%s'.", model_name))
+    insight::format_alert(sprintf("Can't find object '%s'.", model_name))
     return(x)
   }
 
@@ -390,7 +390,7 @@ plot.see_equivalence_test_lm <- function(x,
   # check for user defined arguments
 
   fill.color <- c("#CD423F", "#018F77", "#FCDA3B")
-  legend.title <- "Decision on H0"
+  legend.title <- "Equivalence"
   x.title <- NULL
 
   fill.color <- fill.color[sort(unique(match(x$ROPE_Equivalence, c("Accepted", "Rejected", "Undecided"))))]


### PR DESCRIPTION
I had a discussion with @vincentarelbundock, and the labelling "Decision on H0" and "accepted" (in the context of frequentist frameworks), is only shared by few authors. I think the most general and safe way to describe our results is to "accept equivalence". This is done for the print-method already, and we should do this for plot as well.

``` r
library(parameters)
data(qol_cancer)
model <- lm(QoL ~ time + age + education, data = qol_cancer)
et <- equivalence_test(model)

et
#> # TOST-test for Practical Equivalence
#> 
#>   ROPE: [-1.99 1.99]
#> 
#> Parameter        |         90% CI |   SGPV | Equivalence |      p
#> -----------------------------------------------------------------
#> (Intercept)      | [59.33, 68.41] | < .001 |    Rejected | > .999
#> time             | [-0.76,  2.53] | 0.835  |   Undecided | 0.137 
#> age              | [-0.26,  0.32] | > .999 |    Accepted | < .001
#> education [mid]  | [ 5.13, 12.39] | < .001 |    Rejected | 0.999 
#> education [high] | [10.14, 18.57] | < .001 |    Rejected | > .999

plot(et)
```

![](https://i.imgur.com/AU4em3I.png)<!-- -->

<sup>Created on 2023-04-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
