### PR TITLE
Fix error with `describe_distribution()` with `select`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.7.5.5
+Version: 0.7.5.6
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
 
 * Fixes issue in `plot.binned_residuals()` for models whose residuals were
   completely inside error bounds.
+  
+* `plot()` now works when using it on the output of `describe_distribution()` with
+  a `select` argument of length 1.
 
 # see 0.7.5
 

--- a/R/plot.describe_distribution.R
+++ b/R/plot.describe_distribution.R
@@ -1,6 +1,6 @@
 #' @export
 data_plot.parameters_distribution <- function(x, data = NULL, ...) {
-  if (nrow(x) == 1) {
+  if (nrow(x) == 1 && is.null(x$Variable)) {
     dataplot <- data.frame(
       x = data,
       stringsAsFactors = FALSE
@@ -71,7 +71,7 @@ plot.see_parameters_distribution <- function(x,
 
   # only keep variables used in "describe_distribution()"
   if (!is.null(x$Variable)) {
-    data <- data[x$Variable]
+    data <- data[, x$Variable, drop = FALSE]
   }
 
   if (!inherits(x, "data_plot")) {

--- a/tests/testthat/test-plot.describe_distribution.R
+++ b/tests/testthat/test-plot.describe_distribution.R
@@ -3,4 +3,10 @@ test_that("`plot.see_parameters_distribution()` works", {
   x <- sample(1:100, 1000, replace = TRUE)
   result <- datawizard::describe_distribution(x)
   expect_s3_class(plot(result), "gg")
+
+  result <- datawizard::describe_distribution(iris)
+  expect_true(all(vapply(plot(result), inherits, "gg", FUN.VALUE = logical(1L))))
+
+  result <- datawizard::describe_distribution(iris, select = "Sepal.Length")
+  expect_true(all(vapply(plot(result), inherits, "gg", FUN.VALUE = logical(1L))))
 })


### PR DESCRIPTION
Close #287 

``` r
library(datawizard)
library(see)

x <- describe_distribution(iris, select = "Sepal.Length")
plot(x)
#> [[1]]
#> `stat_bin()` using `bins = 30`. Pick better value with `binwidth`.
```

![](https://i.imgur.com/9raGhoN.png)<!-- -->

``` r

x <- describe_distribution(iris, select = starts_with("Sepal"))
plot(x)
#> [[1]]
#> `stat_bin()` using `bins = 30`. Pick better value with `binwidth`.
```

![](https://i.imgur.com/pscN9I9.png)<!-- -->

    #> 
    #> [[2]]
    #> `stat_bin()` using `bins = 30`. Pick better value with `binwidth`.

![](https://i.imgur.com/u8hBv0G.png)<!-- -->


