### PR TITLE
Improved q-q plot error bands

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -97,7 +97,7 @@ Suggests:
     patchwork,
     poorman,
     psych,
-    qqplotr,
+    qqplotr (>= 0.0.6),
     randomForest,
     rlang,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.8.0.2
+Version: 0.8.0.3
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * QQ/PP-plots now default to drawing simultaneous testing bands (when the
   `qqplotr` package is available). Previous behavior can be restored by setting
   `method = "pointwise"`.
+* Plot method for `performance::check_normality()` now default to a detrended 
+  QQ-plot. Previous behavior can be restored by setting `type = "density"`.
 
 # see 0.8.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * The `print()` method for `performance::check_model()` now also evaluates the
   default plot type for posterior predictive checks.
+* QQ/PP-plots now default to drawing simultaneous testing bands (when the
+  `qqplotr` package is available). Previous behavior can be restored by setting
+  `method = "pointwise"`.
 
 # see 0.8.0
 

--- a/R/plot.check_normality.R
+++ b/R/plot.check_normality.R
@@ -10,6 +10,9 @@
 #' @param colors Character vector of length two, indicating the colors (in
 #'   hex-format) for points and line.
 #' @param detrend Logical that decides if the plot should be detrended.
+#' @param method The method used for estimating the qq/pp bands. Default to
+#'   `"ell"` (equal local levels / simultaneous testing - recommended). See
+#'   `qqplotr::stat_qq_band()` for more options and details.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters
 #'
@@ -31,6 +34,7 @@ plot.see_check_normality <- function(x,
                                      dot_alpha = 0.8,
                                      colors = c("#3aaf85", "#1b6ca8"),
                                      detrend = FALSE,
+                                     method = "ell",
                                      ...) {
   type <- match.arg(type)
 
@@ -75,7 +79,8 @@ plot.see_check_normality <- function(x,
         alpha_level = alpha,
         detrend = detrend,
         dot_alpha_level = dot_alpha,
-        model_info = model_info
+        model_info = model_info,
+        method = method
       )
     } else if (type == "density") {
       r <- suppressMessages(stats::residuals(model))
@@ -95,7 +100,8 @@ plot.see_check_normality <- function(x,
         size_line = size_line,
         alpha_level = alpha,
         detrend = detrend,
-        dot_alpha_level = dot_alpha
+        dot_alpha_level = dot_alpha,
+        method = method
       )
     }
   }
@@ -145,6 +151,7 @@ plot.see_check_normality <- function(x,
                           size_line,
                           alpha_level = 0.2,
                           detrend = FALSE,
+                          method = "ell",
                           theme_style = theme_lucid,
                           colors = unname(social_colors(c("green", "blue", "red"))),
                           dot_alpha_level = 0.8,
@@ -175,7 +182,8 @@ plot.see_check_normality <- function(x,
     qq_stuff <- list(
       qqplotr::stat_qq_band(
         alpha = alpha_level,
-        detrend = detrend
+        detrend = detrend,
+        bandType = method
       ),
       qqplotr::stat_qq_point(
         shape = 16,
@@ -246,12 +254,13 @@ plot.see_check_normality <- function(x,
                           size_line,
                           alpha_level = 0.2,
                           detrend = FALSE,
+                          method = "ell",
                           theme_style = theme_lucid,
                           colors = unname(social_colors(c("green", "blue", "red"))),
                           dot_alpha_level = 0.8) {
   if (requireNamespace("qqplotr", quietly = TRUE)) {
     p_plot <- ggplot2::ggplot(x, ggplot2::aes(sample = .data$res)) +
-      qqplotr::stat_pp_band(alpha = alpha_level, detrend = detrend) +
+      qqplotr::stat_pp_band(alpha = alpha_level, detrend = detrend, bandType = method) +
       qqplotr::stat_pp_line(
         linewidth = size_line,
         colour = colors[1],

--- a/R/plot.check_normality.R
+++ b/R/plot.check_normality.R
@@ -26,6 +26,10 @@
 #' m <<- lm(mpg ~ wt + cyl + gear + disp, data = mtcars)
 #' result <- check_normality(m)
 #' plot(result)
+#'
+#' @examplesIf require("performance") && require("qqplotr")
+#' plot(result, type = "qq", detrend = TRUE)
+#'
 #' @export
 plot.see_check_normality <- function(x,
                                      type = c("density", "qq", "pp"),

--- a/R/plot.check_normality.R
+++ b/R/plot.check_normality.R
@@ -11,8 +11,10 @@
 #'   hex-format) for points and line.
 #' @param detrend Logical that decides if the plot should be detrended.
 #' @param method The method used for estimating the qq/pp bands. Default to
-#'   `"ell"` (equal local levels / simultaneous testing - recommended). See
-#'   `qqplotr::stat_qq_band()` for more options and details.
+#'   `"ell"` (equal local levels / simultaneous testing - recommended). Can also
+#'   be one of `"pointwise"` or `"boot"` for pointwise confidence bands, or
+#'   `"ks"` or `"ts"` for simultaneous testing. See `qqplotr::stat_qq_band()`
+#'   for details.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters
 #'

--- a/R/plot.check_normality.R
+++ b/R/plot.check_normality.R
@@ -4,12 +4,16 @@
 #' function.
 #'
 #' @param type Character vector, indicating the type of plot.
+#'   Options are `"qq"` (default) for quantile-quantile (Q-Q) plots,
+#'   `"pp"` for probability-probability (P-P) plots, or
+#'   `"density"` for density overlay plots.
 #' @param size_line Numeric value specifying size of line geoms.
 #' @param dot_alpha Numeric value specifying alpha level of the point geoms.
 #' @param alpha Numeric value specifying alpha level of the confidence bands.
 #' @param colors Character vector of length two, indicating the colors (in
 #'   hex-format) for points and line.
-#' @param detrend Logical that decides if the plot should be detrended.
+#' @param detrend Logical that decides if Q-Q and P-P plots should be de-trended.
+#'   Defaults to `TRUE` if the *qqplotr* package is installed and `FALSE` otherwise.
 #' @param method The method used for estimating the qq/pp bands. Default to
 #'   `"ell"` (equal local levels / simultaneous testing - recommended). Can also
 #'   be one of `"pointwise"` or `"boot"` for pointwise confidence bands, or
@@ -32,14 +36,14 @@
 #'
 #' @export
 plot.see_check_normality <- function(x,
-                                     type = c("density", "qq", "pp"),
+                                     type = c("qq", "pp", "density"),
                                      data = NULL,
                                      size_line = 0.8,
                                      size_point = 2,
                                      alpha = 0.2,
                                      dot_alpha = 0.8,
                                      colors = c("#3aaf85", "#1b6ca8"),
-                                     detrend = FALSE,
+                                     detrend = requireNamespace("qqplotr", quietly = TRUE),
                                      method = "ell",
                                      ...) {
   type <- match.arg(type)
@@ -302,15 +306,15 @@ plot.see_check_normality <- function(x,
         alpha = dot_alpha_level
       ) # "#2c3e50"
   } else {
-    stop("Package 'qqplotr' OR 'MASS' required for PP-plots. Please install one of them.", call. = FALSE)
+    stop("Package 'qqplotr' OR 'MASS' required for P-P plots. Please install one of them.", call. = FALSE)
   }
 
   p_plot +
     ggplot2::labs(
-      title = "Normality of Residuals (PP plot)",
+      title = "Normality of Residuals",
       subtitle = "Dots should fall along the line",
-      y = "Cummulative Probability",
-      x = "Probability Points"
+      y = "Sample Cummulative Probability",
+      x = "Standard Normal Cumulative Probability"
     ) +
     theme_style(
       base_size = 10,

--- a/R/plot.check_normality.R
+++ b/R/plot.check_normality.R
@@ -236,7 +236,7 @@ plot.see_check_normality <- function(x,
       }
       ,
       ggplot2::geom_qq(
-        mapping = if (detrend) ggplot2::aes(y = ggplot2::after_stat(sample) - ggplot2::after_stat(theoretical)),
+        mapping = if (detrend) ggplot2::aes(y = ggplot2::after_stat("sample") - ggplot2::after_stat("theoretical")),
         shape = 16,
         na.rm = TRUE,
         stroke = 0,

--- a/R/plot.check_outliers.R
+++ b/R/plot.check_outliers.R
@@ -3,6 +3,12 @@
 #' The `plot()` method for the `performance::check_outliers()`
 #' function.
 #'
+#' @param type Character vector, indicating the type of plot.
+#'   Options are `"dots"` (default) for a scatterplot of leverage (hat) values
+#'   versus residuals, with Cook's Distance contours for evaluating influential
+#'   points, or `"bars"` for a bar chart of (rescaled) outlier statistic values
+#'   for each data point. Only used for outlier plots of fitted models; for
+#'   outlier plots of raw data values, `type = "bars"` is always used.
 #' @param show_labels Logical. If `TRUE`, text labels are displayed.
 #' @param size_text Numeric value specifying size of text labels.
 #' @param rescale_distance Logical. If `TRUE`, distance values are rescaled

--- a/R/plot.n_factors.R
+++ b/R/plot.n_factors.R
@@ -66,6 +66,12 @@ data_plot.n_clusters <- data_plot.n_factors
 #'
 #' The `plot()` method for the `parameters::n_factors()` and `parameters::n_clusters()`
 #'
+#' @param type Character vector, indicating the type of plot.
+#'   Options are three different shapes to illustrate the degree of consensus
+#'   between dimensionality methods for each number of factors;
+#'    `"bar"` (default) for a bar chart,
+#'    `"line"` for a horizontal point and line chart, or
+#'   `"area"` for an area chart (frequency polygon).
 #' @param size Depending on `type`, a numeric value specifying size of bars,
 #'   lines, or segments.
 #' @inheritParams data_plot

--- a/R/plot.parameters_pca.R
+++ b/R/plot.parameters_pca.R
@@ -55,6 +55,10 @@ data_plot.parameters_efa <- data_plot.parameters_pca
 #'
 #' The `plot()` method for the `parameters::principal_components()` function.
 #'
+#' @param type Character vector, indicating the type of plot.
+#'   Options are three different shapes to represent component loadings;
+#'    `"bar"` (default) for a horizontal bar chart, or
+#'    `"line"` for a horizontal point and line chart.
 #' @param text_color Character specifying color of text labels.
 #' @inheritParams data_plot
 #' @inheritParams plot.see_bayesfactor_parameters

--- a/man/plot.see_check_normality.Rd
+++ b/man/plot.see_check_normality.Rd
@@ -6,14 +6,14 @@
 \usage{
 \method{plot}{see_check_normality}(
   x,
-  type = c("density", "qq", "pp"),
+  type = c("qq", "pp", "density"),
   data = NULL,
   size_line = 0.8,
   size_point = 2,
   alpha = 0.2,
   dot_alpha = 0.8,
   colors = c("#3aaf85", "#1b6ca8"),
-  detrend = FALSE,
+  detrend = requireNamespace("qqplotr", quietly = TRUE),
   method = "ell",
   ...
 )
@@ -21,7 +21,10 @@
 \arguments{
 \item{x}{An object.}
 
-\item{type}{Character vector, indicating the type of plot.}
+\item{type}{Character vector, indicating the type of plot.
+Options are \code{"qq"} (default) for quantile-quantile (Q-Q) plots,
+\code{"pp"} for probability-probability (P-P) plots, or
+\code{"density"} for density overlay plots.}
 
 \item{data}{The original data used to create this object. Can be a
 statistical model.}
@@ -37,7 +40,8 @@ statistical model.}
 \item{colors}{Character vector of length two, indicating the colors (in
 hex-format) for points and line.}
 
-\item{detrend}{Logical that decides if the plot should be detrended.}
+\item{detrend}{Logical that decides if Q-Q and P-P plots should be de-trended.
+Defaults to \code{TRUE} if the \emph{qqplotr} package is installed and \code{FALSE} otherwise.}
 
 \item{method}{The method used for estimating the qq/pp bands. Default to
 \code{"ell"} (equal local levels / simultaneous testing - recommended). Can also

--- a/man/plot.see_check_normality.Rd
+++ b/man/plot.see_check_normality.Rd
@@ -60,6 +60,9 @@ m <<- lm(mpg ~ wt + cyl + gear + disp, data = mtcars)
 result <- check_normality(m)
 plot(result)
 \dontshow{\}) # examplesIf}
+\dontshow{if (require("performance") && require("qqplotr")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+plot(result, type = "qq", detrend = TRUE)
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 See also the vignette about \href{https://easystats.github.io/performance/articles/check_model.html}{\code{check_model()}}.

--- a/man/plot.see_check_normality.Rd
+++ b/man/plot.see_check_normality.Rd
@@ -13,7 +13,7 @@
   alpha = 0.2,
   dot_alpha = 0.8,
   colors = c("#3aaf85", "#1b6ca8"),
-  detrend = requireNamespace("qqplotr", quietly = TRUE),
+  detrend = TRUE,
   method = "ell",
   ...
 )
@@ -40,8 +40,8 @@ statistical model.}
 \item{colors}{Character vector of length two, indicating the colors (in
 hex-format) for points and line.}
 
-\item{detrend}{Logical that decides if Q-Q and P-P plots should be de-trended.
-Defaults to \code{TRUE} if the \emph{qqplotr} package is installed and \code{FALSE} otherwise.}
+\item{detrend}{Logical that decides if Q-Q and P-P plots should be de-trended
+(also known as \emph{worm plots}).}
 
 \item{method}{The method used for estimating the qq/pp bands. Default to
 \code{"ell"} (equal local levels / simultaneous testing - recommended). Can also

--- a/man/plot.see_check_normality.Rd
+++ b/man/plot.see_check_normality.Rd
@@ -40,8 +40,10 @@ hex-format) for points and line.}
 \item{detrend}{Logical that decides if the plot should be detrended.}
 
 \item{method}{The method used for estimating the qq/pp bands. Default to
-\code{"ell"} (equal local levels / simultaneous testing - recommended). See
-\code{qqplotr::stat_qq_band()} for more options and details.}
+\code{"ell"} (equal local levels / simultaneous testing - recommended). Can also
+be one of \code{"pointwise"} or \code{"boot"} for pointwise confidence bands, or
+\code{"ks"} or \code{"ts"} for simultaneous testing. See \code{qqplotr::stat_qq_band()}
+for details.}
 
 \item{...}{Arguments passed to or from other methods.}
 }

--- a/man/plot.see_check_normality.Rd
+++ b/man/plot.see_check_normality.Rd
@@ -14,6 +14,7 @@
   dot_alpha = 0.8,
   colors = c("#3aaf85", "#1b6ca8"),
   detrend = FALSE,
+  method = "ell",
   ...
 )
 }
@@ -37,6 +38,10 @@ statistical model.}
 hex-format) for points and line.}
 
 \item{detrend}{Logical that decides if the plot should be detrended.}
+
+\item{method}{The method used for estimating the qq/pp bands. Default to
+\code{"ell"} (equal local levels / simultaneous testing - recommended). See
+\code{qqplotr::stat_qq_band()} for more options and details.}
 
 \item{...}{Arguments passed to or from other methods.}
 }

--- a/man/plot.see_check_outliers.Rd
+++ b/man/plot.see_check_outliers.Rd
@@ -32,7 +32,12 @@ hex-format) for points and line.}
 to a range from 0 to 1. This is mainly due to better catch the differences
 between distance values.}
 
-\item{type}{Character vector, indicating the type of plot.}
+\item{type}{Character vector, indicating the type of plot.
+Options are \code{"dots"} (default) for a scatterplot of leverage (hat) values
+versus residuals, with Cook's Distance contours for evaluating influential
+points, or \code{"bars"} for a bar chart of (rescaled) outlier statistic values
+for each data point. Only used for outlier plots of fitted models; for
+outlier plots of raw data values, \code{type = "bars"} is always used.}
 
 \item{show_labels}{Logical. If \code{TRUE}, text labels are displayed.}
 

--- a/man/plot.see_n_factors.Rd
+++ b/man/plot.see_n_factors.Rd
@@ -12,7 +12,12 @@
 \item{data}{The original data used to create this object. Can be a
 statistical model.}
 
-\item{type}{Character vector, indicating the type of plot.}
+\item{type}{Character vector, indicating the type of plot.
+Options are three different shapes to illustrate the degree of consensus
+between dimensionality methods for each number of factors;
+\code{"bar"} (default) for a bar chart,
+\code{"line"} for a horizontal point and line chart, or
+\code{"area"} for an area chart (frequency polygon).}
 
 \item{size}{Depending on \code{type}, a numeric value specifying size of bars,
 lines, or segments.}

--- a/man/plot.see_parameters_pca.Rd
+++ b/man/plot.see_parameters_pca.Rd
@@ -17,7 +17,10 @@
 \arguments{
 \item{x}{An object.}
 
-\item{type}{Character vector, indicating the type of plot.}
+\item{type}{Character vector, indicating the type of plot.
+Options are three different shapes to represent component loadings;
+\code{"bar"} (default) for a horizontal bar chart, or
+\code{"line"} for a horizontal point and line chart.}
 
 \item{size_text}{Numeric value specifying size of text labels.}
 

--- a/tests/testthat/_snaps/plot.check_normality/check-normality-works-lm-pp.svg
+++ b/tests/testthat/_snaps/plot.check_normality/check-normality-works-lm-pp.svg
@@ -9,7 +9,7 @@
       stroke-linejoin: round;
       stroke-miterlimit: 10.00;
     }
-  ]]></style>
+  ]]></style>qq
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
 <defs>
@@ -95,9 +95,9 @@
 <text x='379.39' y='554.11' text-anchor='middle' style='font-size: 10.00px; fill: #7F7F7F; font-family: sans;' textLength='19.46px' lengthAdjust='spacingAndGlyphs'>0.50</text>
 <text x='531.95' y='554.11' text-anchor='middle' style='font-size: 10.00px; fill: #7F7F7F; font-family: sans;' textLength='19.46px' lengthAdjust='spacingAndGlyphs'>0.75</text>
 <text x='684.51' y='554.11' text-anchor='middle' style='font-size: 10.00px; fill: #7F7F7F; font-family: sans;' textLength='19.46px' lengthAdjust='spacingAndGlyphs'>1.00</text>
-<text x='379.39' y='568.74' text-anchor='middle' style='font-size: 11.00px; fill: #4D4D4D; font-family: sans;' textLength='84.99px' lengthAdjust='spacingAndGlyphs'>Probability Points</text>
-<text transform='translate(12.55,287.70) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; fill: #4D4D4D; font-family: sans;' textLength='118.62px' lengthAdjust='spacingAndGlyphs'>Cummulative Probability</text>
+<text x='379.39' y='568.74' text-anchor='middle' style='font-size: 11.00px; fill: #4D4D4D; font-family: sans;' textLength='84.99px' lengthAdjust='spacingAndGlyphs'>Standard Normal Cumulative Probability</text>
+<text transform='translate(12.55,287.70) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; fill: #4D4D4D; font-family: sans;' textLength='118.62px' lengthAdjust='spacingAndGlyphs'>Sample Cummulative Probability</text>
 <text x='4.98' y='25.60' style='font-size: 10.00px; font-family: sans;' textLength='130.64px' lengthAdjust='spacingAndGlyphs'>Dots should fall along the line</text>
-<text x='4.98' y='13.24' style='font-size: 12.00px; font-family: sans;' textLength='170.08px' lengthAdjust='spacingAndGlyphs'>Normality of Residuals (PP plot)</text>
+<text x='4.98' y='13.24' style='font-size: 12.00px; font-family: sans;' textLength='170.08px' lengthAdjust='spacingAndGlyphs'>Normality of Residuals</text>
 </g>
 </svg>


### PR DESCRIPTION
Closes https://github.com/easystats/performance/issues/599

@bwiernik Should this be the new default qq/pp-band method?

Note that currently the default plot is a density plot.... I would rather it be a qq-plot, don't you think?

``` r
library(performance)
library(see)

m <- lm(mpg ~ ., mtcars)
```

Old qq-plot

``` r
check_normality(m) |> plot(type = "qq", method = "pointwise") + 
  ggplot2::coord_cartesian(ylim = c(-2, 2))
```

![](https://i.imgur.com/GlfbdQe.png)<!-- -->

qq-plots with the new `"ell"` default

``` r
check_normality(m) |> plot(type = "qq") + 
  ggplot2::coord_cartesian(ylim = c(-2, 2))
```

![](https://i.imgur.com/Gf4tb2L.png)<!-- -->

``` r

# Compare to `qqconf`
qqconf::qq_conf_plot(rstandard(m))
#> no dparams supplied. Estimating parameters from the data...
```

![](https://i.imgur.com/Z1ycerr.png)<!-- -->

pp-plots with the new `"ell"` default

``` r
check_normality(m) |> plot(type = "pp")
```

![](https://i.imgur.com/sL11QTk.png)<!-- -->

``` r

# Compare to `qqconf`
qqconf::pp_conf_plot(rstandard(m))
#> no dparams supplied. Estimating parameters from the data...
```

![](https://i.imgur.com/kZvKenT.png)<!-- -->

<sup>Created on 2023-07-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
