### PR TITLE
Rotate x-axis labels by default for plot method for `check_outliers()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.8.1.1
+Version: 0.8.1.2
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",
@@ -117,4 +117,4 @@ Config/Needs/website:
     rstudio/bslib,
     r-lib/pkgdown,
     easystats/easystatstemplate
-Remotes: easystats/parameters, easystats/bayestestR
+Remotes: easystats/bayestestR

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * `plot.n_factors()` now shows a dashed line over the bars, indicating the
   cumulate explained variance by the number of factors.
 
+* `plot.check_outliers()` now dodges the x-axis labels, to avoid overlapping
+  labels.
+
 # see 0.8.1
 
 ## Major Changes

--- a/R/plot.check_outliers.R
+++ b/R/plot.check_outliers.R
@@ -145,7 +145,7 @@ data_plot.check_outliers <- function(x, data = NULL, rescale_distance = TRUE, ..
     }
   }
 
-  p
+  p + guides(x = guide_axis(n.dodge = 2))
 }
 
 
@@ -182,6 +182,7 @@ data_plot.check_outliers <- function(x, data = NULL, rescale_distance = TRUE, ..
           linetype = "dashed",
           colour = ifelse(as.numeric(x) >= 0.5, "red", "lightgrey")
         )
-      )
+      ) +
+      guides(x = guide_axis(n.dodge = 2))
   )
 }


### PR DESCRIPTION
Fixes #317