### PR TITLE
Fix for compare_parameters(effects = "random")

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.8.3.5
+Version: 0.8.3.6
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
 * `plot()` for `check_predictions()` now supports Bayesian regression models from
   *brms* and *rstanarm*.
 
+## Bug fixes
+
+* Corrected order of models for `plot.compare_parameters()`.
+
 # see 0.8.3
 
 ## Major changes

--- a/R/plot.compare_parameters.R
+++ b/R/plot.compare_parameters.R
@@ -210,14 +210,19 @@ data_plot.see_compare_parameters <- function(x, ...) {
     values_to = "CI_high",
     columns = colnames(x)[col_ci_high]
   )["CI_high"]
+  dataplot <- cbind(out1, out2, out3)
 
-  out4 <- .reshape_to_long(
-    x,
-    values_to = "p",
-    columns = colnames(x)[col_p]
-  )["p"]
+  # if we have effects = "random", we probably don't have p-values. so
+  # check if this column exists, and if not, we skip it...
+  if (length(col_p) != 0) {
+    out4 <- .reshape_to_long(
+      x,
+      values_to = "p",
+      columns = colnames(x)[col_p]
+    )["p"]
+    dataplot <- cbind(dataplot, out4)
+  }
 
-  dataplot <- cbind(out1, out2, out3, out4)
   dataplot$group <- gsub("(.*)\\.(.*)", "\\2", dataplot$group)
 
   rownames(dataplot) <- NULL

--- a/R/plot.compare_parameters.R
+++ b/R/plot.compare_parameters.R
@@ -127,19 +127,19 @@ plot.see_compare_parameters <- function(x,
   # largest data points that are within this range. Thereby we have the pretty
   # values we can use as breaks and labels for the scale...
   if (exponentiated_coefs) {
-    range <- 2^(-24:16)
-    x_low <- which.min(min(x$CI_low) > range) - 1L
-    x_high <- which.max(max(x$CI_high) < range)
+    exp_range <- 2^(-24:16)
+    x_low <- which.min(min(x$CI_low) > exp_range) - 1L
+    x_high <- which.max(max(x$CI_high) < exp_range)
     if (add_values) {
       # add some space to the right panel for text
       new_range <- pretty(2 * max(x$CI_high))
-      x_high <- which.max(max(new_range) < range)
+      x_high <- which.max(max(new_range) < exp_range)
     }
     p <- p + scale_x_continuous(
       trans = "log",
-      breaks = range[x_low:x_high],
-      limits = c(range[x_low], range[x_high]),
-      labels = sprintf("%g", range[x_low:x_high])
+      breaks = exp_range[x_low:x_high],
+      limits = c(exp_range[x_low], exp_range[x_high]),
+      labels = sprintf("%g", exp_range[x_low:x_high])
     )
   }
 
@@ -192,7 +192,7 @@ plot.see_compare_parameters <- function(x,
 
 #' @export
 data_plot.see_compare_parameters <- function(x, ...) {
-  col_coefficient <- which(grepl("^(Coefficient|Log-Odds|Log-Mean|Odds Ratio|Risk Ratio|IRR)\\.", colnames(x)))
+  col_coefficient <- grep("^(Coefficient|Log-Odds|Log-Mean|Odds Ratio|Risk Ratio|IRR)\\.", colnames(x))
   col_ci_low <- which(startsWith(colnames(x), "CI_low."))
   col_ci_high <- which(startsWith(colnames(x), "CI_high."))
   col_p <- which(startsWith(colnames(x), "p."))

--- a/R/plot.compare_parameters.R
+++ b/R/plot.compare_parameters.R
@@ -80,7 +80,7 @@ plot.see_compare_parameters <- function(x,
     x <- x[!.is_intercept(x$Parameter), ]
     # sanity check - any data left?
     if (nrow(x) == 0) {
-      insight::format_warning("No data left after removing intercepts. Returning empty plot.")
+      insight::format_warning("No data left after removing intercepts. Returning empty plot. Try `show_intercept = TRUE`.") # nolint
     }
   }
 

--- a/R/plot.compare_parameters.R
+++ b/R/plot.compare_parameters.R
@@ -75,9 +75,13 @@ plot.see_compare_parameters <- function(x,
     x$Component <- factor(x$Component, levels = unique(x$Component))
   }
 
-
+  # show/hide intercepts
   if (!show_intercept) {
     x <- x[!.is_intercept(x$Parameter), ]
+    # sanity check - any data left?
+    if (nrow(x) == 0) {
+      insight::format_warning("No data left after removing intercepts. Returning empty plot.")
+    }
   }
 
   if (isTRUE(sort) || (!is.null(sort) && sort == "ascending")) {
@@ -224,6 +228,8 @@ data_plot.see_compare_parameters <- function(x, ...) {
   }
 
   dataplot$group <- gsub("(.*)\\.(.*)", "\\2", dataplot$group)
+  # make factor, so order in legend is preserved
+  dataplot$group <- factor(dataplot$group, levels = unique(dataplot$group))
 
   rownames(dataplot) <- NULL
 

--- a/tests/testthat/_snaps/plot.compare_parameters/plot-compare-parameters-works.svg
+++ b/tests/testthat/_snaps/plot.compare_parameters/plot-compare-parameters-works.svg
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMTE2LjY4fDU3OC40N3wzOC44NHw1MjMuMjc='>
+    <rect x='116.68' y='38.84' width='461.79' height='484.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTE2LjY4fDU3OC40N3wzOC44NHw1MjMuMjc=)'>
+<rect x='116.68' y='38.84' width='461.79' height='484.43' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='137.67' y1='523.27' x2='137.67' y2='38.84' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<line x1='171.53' y1='200.32' x2='557.48' y2='200.32' style='stroke-width: 1.07; stroke: #F44336; stroke-linecap: butt;' />
+<circle cx='137.67' cy='361.79' r='4.12' style='stroke-width: 1.42; stroke: #2196F3; fill: #2196F3;' />
+<circle cx='256.89' cy='200.32' r='4.12' style='stroke-width: 1.42; stroke: #F44336; fill: #F44336;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='116.68,523.27 116.68,38.84 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='111.75' y='285.18' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='74.70px' lengthAdjust='spacingAndGlyphs'>SD (Intercept)</text>
+<polyline points='116.68,523.27 578.47,523.27 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='137.67' y='536.46' text-anchor='middle' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='236.75' y='536.46' text-anchor='middle' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='335.82' y='536.46' text-anchor='middle' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='434.89' y='536.46' text-anchor='middle' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='533.97' y='536.46' text-anchor='middle' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<text x='347.57' y='567.82' text-anchor='middle' style='font-size: 13.00px; font-family: sans;' textLength='50.58px' lengthAdjust='spacingAndGlyphs'>Estimate</text>
+<text transform='translate(14.43,281.06) rotate(-90)' text-anchor='middle' style='font-size: 13.00px; font-family: sans;' textLength='60.70px' lengthAdjust='spacingAndGlyphs'>Parameter</text>
+<rect x='589.43' y='249.73' width='125.09' height='62.64' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='594.91' y='265.51' style='font-size: 13.00px; font-family: sans;' textLength='35.41px' lengthAdjust='spacingAndGlyphs'>Model</text>
+<line x1='596.63' y1='280.98' x2='610.46' y2='280.98' style='stroke-width: 1.07; stroke: #2196F3; stroke-linecap: butt;' />
+<circle cx='603.55' cy='280.98' r='4.12' style='stroke-width: 1.42; stroke: #2196F3; fill: #2196F3;' />
+<line x1='596.63' y1='298.26' x2='610.46' y2='298.26' style='stroke-width: 1.07; stroke: #F44336; stroke-linecap: butt;' />
+<circle cx='603.55' cy='298.26' r='4.12' style='stroke-width: 1.42; stroke: #F44336; fill: #F44336;' />
+<text x='617.67' y='285.11' style='font-size: 12.00px; font-family: sans;' textLength='66.71px' lengthAdjust='spacingAndGlyphs'>gmod_glmer</text>
+<text x='617.67' y='302.39' style='font-size: 12.00px; font-family: sans;' textLength='91.38px' lengthAdjust='spacingAndGlyphs'>gmod_glmmTMB</text>
+<text x='5.48' y='15.80' style='font-size: 15.00px; font-family: sans;' textLength='214.30px' lengthAdjust='spacingAndGlyphs'>plot.compare_parameters works</text>
+</g>
+</svg>

--- a/tests/testthat/test-plot.compare_parameters.R
+++ b/tests/testthat/test-plot.compare_parameters.R
@@ -1,0 +1,24 @@
+test_that("`plot()` for compare_parameters", {
+  skip_if_not_installed("glmmTMB")
+  skip_if_not_installed("lme4")
+  skip_if_not_installed("parameters")
+  gdat <- readRDS(system.file("vignette_data", "gophertortoise.rds", package = "glmmTMB"))
+  form <- shells ~ prev + offset(log(Area)) + factor(year) + (1 | Site)
+  gmod_glmer <- lme4::glmer(form, family = poisson, data = gdat)
+  gprior <- data.frame(
+    prior = "gamma(1e8, 2.5)",
+    class = "theta",
+    coef = "",
+    stringsAsFactors = FALSE
+  )
+  gmod_glmmTMB <- glmmTMB(form, family = poisson, priors = gprior, data = gdat)
+
+  cp <- parameters::compare_parameters(gmod_glmer, gmod_glmmTMB, effects = "random")
+  expect_warning(plot(cp), "No data left")
+
+  skip_if_not_installed("vdiffr")
+  vdiffr::expect_doppelganger(
+    title = "plot.compare_parameters works",
+    fig = plot(cp, show_intercept = TRUE)
+  )
+})

--- a/tests/testthat/test-plot.compare_parameters.R
+++ b/tests/testthat/test-plot.compare_parameters.R
@@ -11,7 +11,7 @@ test_that("`plot()` for compare_parameters", {
     coef = "",
     stringsAsFactors = FALSE
   )
-  gmod_glmmTMB <- glmmTMB(form, family = poisson, priors = gprior, data = gdat)
+  gmod_glmmTMB <- glmmTMB::glmmTMB(form, family = poisson, priors = gprior, data = gdat)
 
   cp <- parameters::compare_parameters(gmod_glmer, gmod_glmmTMB, effects = "random")
   expect_warning(plot(cp), "No data left")


### PR DESCRIPTION
```r
library(glmmTMB)
library(lme4)
library(blme)
library(ggplot2); theme_set(theme_bw())
library(easystats)

gdat <- readRDS(system.file("vignette_data", "gophertortoise.rds", package = "glmmTMB"))
form <- shells~prev + offset(log(Area)) + factor(year) + (1 | Site)
gmod_glmer <- glmer(form, family = poisson, data = gdat)

gmod_bglmer <- bglmer(form, family=poisson, data=gdat)
## cov.prior = gamma(shape = 2.5, rate = 0, common.scale = TRUE, posterior.scale = "sd"))
gmod_glmmTMB <- glmmTMB(form, family = poisson, data = gdat) ## 1e-5
## bglmer default corresponds to gamma(Inf, 2.5)
gprior <- data.frame(prior = "gamma(1e8, 2.5)",
                     class = "theta",
                     coef = "")
gmod_glmmTMB_p <- update(gmod_glmmTMB, priors = gprior)
vc1 <- c(VarCorr(gmod_glmmTMB_p)$cond$Site)
vc2 <- c(VarCorr(gmod_bglmer)$Site)
all.equal(vc1, vc2, tolerance = 5e-4)

compare_parameters(
  gmod_glmer, gmod_glmmTMB, gmod_bglmer, gmod_glmmTMB_p,
  effects = "random"
) |> plot()
```
