### PR TITLE
Allow to add global aes when plotting `visualisation_recipe()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.10.0
+Version: 0.10.0.2
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/R/plot.visualisation_recipe.R
+++ b/R/plot.visualisation_recipe.R
@@ -7,8 +7,16 @@ plot.see_visualisation_recipe <- function(x, ...) {
     }
     suppressWarnings(ggraph::ggraph(attributes(x)$data, layout = attributes(x)$layout) + geoms_from_list(x))
   } else {
-    suppressWarnings(ggplot2::ggplot(data = attributes(x)$data) +
-      geoms_from_list(x, ...))
+    global_aes <- attributes(x)$global_aes
+    if (!is.null(global_aes) && length(global_aes)) {
+      global_aes <- do.call(ggplot2::aes, args = lapply(global_aes, .str_to_sym))
+    }
+    suppressWarnings(
+      do.call(
+        ggplot2::ggplot,
+        insight::compact_list(list(data = attributes(x)$data, mapping = global_aes))
+      ) + geoms_from_list(x, ...)
+    )
   }
 }
 


### PR DESCRIPTION
There are situations, where we need to map aes to the global call to `ggplot()`, and not inside a geom. E.g., Johnson-Neyman plots from _modelbased_ need a `group` aes for the ribbons, but it's not allowed to be part of the geom_ribbon-aes (ggplot errors for more than two groups).

In this case, we need to put the aes into the `ggplot()` call. This is what this PR implements.

Here we have three "groups":

![image](https://github.com/user-attachments/assets/bb3b8043-69eb-46f4-b4da-3328f27fcb02)
