### PR TITLE
Color scales select best default palette based on whether discrete or continuous scales are requested.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.10.0.7
+Version: 0.10.0.8
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,9 +16,11 @@
   to the plot and slightly increase the distance between axis labels and the
   related axis.
 
-* Color scale functions (those starting with `scale_*()`) now automatically
-  select an appropriate palette (usually, `"contrast"` or `"complement"`)
-  depending on whether discrete or continuous color scales are requested.
+* Color scale functions (those starting with `scale_*()`) get a new `"gradient"`
+  palette, which are simply the color values for blue and orange colors from that
+  palette. Furthermore, color scale functions now automatically select an
+  appropriate palette (usually, `"contrast"` or `"gradient"`) depending on
+  whether discrete or continuous color scales are requested.
 
 # see 0.10.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
   to the plot and slightly increase the distance between axis labels and the
   related axis.
 
+* Color scale functions (those starting with `scale_*()`) now automatically
+  select an appropriate palette (usually, `"contrast"` or `"complement"`)
+  depending on whether discrete or continuous color scales are requested.
+
 # see 0.10.0
 
 ## Changes

--- a/R/scale_color_bluebrown.R
+++ b/R/scale_color_bluebrown.R
@@ -25,7 +25,7 @@ scale_color_bluebrown <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -101,7 +101,7 @@ scale_fill_bluebrown <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -191,7 +191,8 @@ bluebrown_palettes <- list(
   full = bluebrown_colors(),
   contrast = bluebrown_colors("lightblue", "blue", "darkblue", "grey", "darkbrown", "brown", "lightbrown"),
   rainbow = bluebrown_colors("darkblue", "blue", "lightblue", "grey", "lightbrown", "brown", "darkbrown"),
-  complement = bluebrown_colors("darkblue", "blue", "lightblue", "grey", "lightbrown", "brown", "darkbrown")
+  complement = bluebrown_colors("darkblue", "blue", "lightblue", "grey", "lightbrown", "brown", "darkbrown"),
+  gradient = bluebrown_colors("blue", "brown")
 )
 
 

--- a/R/scale_color_bluebrown.R
+++ b/R/scale_color_bluebrown.R
@@ -16,7 +16,19 @@
 #'   theme_modern() +
 #'   scale_fill_bluebrown_d()
 #' @export
-scale_color_bluebrown <- function(palette = "contrast", discrete = TRUE, reverse = FALSE, aesthetics = "color", ...) {
+scale_color_bluebrown <- function(palette = NULL,
+                                  discrete = TRUE,
+                                  reverse = FALSE,
+                                  aesthetics = "color",
+                                  ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_bluebrown(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -32,7 +44,7 @@ scale_color_bluebrown <- function(palette = "contrast", discrete = TRUE, reverse
 
 #' @rdname scale_color_bluebrown
 #' @export
-scale_color_bluebrown_d <- function(palette = "contrast",
+scale_color_bluebrown_d <- function(palette = NULL,
                                     discrete = TRUE,
                                     reverse = FALSE,
                                     aesthetics = "color",
@@ -48,7 +60,7 @@ scale_color_bluebrown_d <- function(palette = "contrast",
 
 #' @rdname scale_color_bluebrown
 #' @export
-scale_color_bluebrown_c <- function(palette = "contrast",
+scale_color_bluebrown_c <- function(palette = NULL,
                                     discrete = FALSE,
                                     reverse = FALSE,
                                     aesthetics = "color",
@@ -80,11 +92,19 @@ scale_colour_bluebrown_d <- scale_color_bluebrown_d
 
 #' @rdname scale_color_bluebrown
 #' @export
-scale_fill_bluebrown <- function(palette = "contrast",
+scale_fill_bluebrown <- function(palette = NULL,
                                  discrete = TRUE,
                                  reverse = FALSE,
                                  aesthetics = "fill",
                                  ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_bluebrown(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -97,7 +117,7 @@ scale_fill_bluebrown <- function(palette = "contrast",
 
 #' @rdname scale_color_bluebrown
 #' @export
-scale_fill_bluebrown_d <- function(palette = "contrast",
+scale_fill_bluebrown_d <- function(palette = NULL,
                                    discrete = TRUE,
                                    reverse = FALSE,
                                    aesthetics = "fill",
@@ -113,7 +133,7 @@ scale_fill_bluebrown_d <- function(palette = "contrast",
 
 #' @rdname scale_color_bluebrown
 #' @export
-scale_fill_bluebrown_c <- function(palette = "contrast",
+scale_fill_bluebrown_c <- function(palette = NULL,
                                    discrete = FALSE,
                                    reverse = FALSE,
                                    aesthetics = "fill",
@@ -132,13 +152,13 @@ scale_fill_bluebrown_c <- function(palette = "contrast",
 
 
 bluebrown_colors_list <- c(
-  `lightblue` = "#6DC0E0",
-  `blue` = "#5B93AE",
-  `darkblue` = "#1F4454",
-  `grey` = "#dbdbdb",
-  `lightbrown` = "#92673C",
-  `brown` = "#61381A",
-  `darkbrown` = "#391D07"
+  lightblue = "#6DC0E0",
+  blue = "#5B93AE",
+  darkblue = "#1F4454",
+  grey = "#dbdbdb",
+  lightbrown = "#92673C",
+  brown = "#61381A",
+  darkbrown = "#391D07"
 )
 
 
@@ -168,9 +188,10 @@ bluebrown_colors <- function(...) {
 
 
 bluebrown_palettes <- list(
-  `full` = bluebrown_colors(),
-  `contrast` = bluebrown_colors("lightblue", "blue", "darkblue", "grey", "darkbrown", "brown", "lightbrown"),
-  `rainbow` = bluebrown_colors("darkblue", "blue", "lightblue", "grey", "lightbrown", "brown", "darkbrown")
+  full = bluebrown_colors(),
+  contrast = bluebrown_colors("lightblue", "blue", "darkblue", "grey", "darkbrown", "brown", "lightbrown"),
+  rainbow = bluebrown_colors("darkblue", "blue", "lightblue", "grey", "lightbrown", "brown", "darkbrown"),
+  complement = bluebrown_colors("darkblue", "blue", "lightblue", "grey", "lightbrown", "brown", "darkbrown")
 )
 
 

--- a/R/scale_color_flat.R
+++ b/R/scale_color_flat.R
@@ -39,7 +39,7 @@ scale_color_flat <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -115,7 +115,7 @@ scale_fill_flat <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -214,6 +214,7 @@ flat_colors <- function(...) {
 flat_palettes <- list(
   full = flat_colors(),
   ice = flat_colors("purple", "deep purple", "blue", "light blue"),
+  gradient = flat_colors("blue", "orange"),
   rainbow = flat_colors(
     "purple",
     "deep purple",
@@ -251,9 +252,9 @@ flat_palettes <- list(
 #' `"light"` (for dark themes), `"black_first"`, `full_original`, or
 #' `black_first_original`. The latter three options are especially for the
 #' Okabe-Ito color palette. The default is `NULL` and either `"contrast"` or
-#' `"complement"` is used (depending on whether `discrete` is `TRUE` or
-#' `FALSE`), which are the two scale useful for discrete or gradient color
-#' scales, respectively.
+#' `"gradient"` is used (depending on whether `discrete` is `TRUE` or `FALSE`),
+#' which are the two scale useful for discrete or gradient color scales,
+#' respectively.
 #' @param reverse Boolean indicating whether the palette should be reversed.
 #' @param ... Additional arguments to pass to [`colorRampPalette()`][colorRampPalette].
 #'

--- a/R/scale_color_flat.R
+++ b/R/scale_color_flat.R
@@ -167,21 +167,21 @@ scale_fill_flat_c <- function(palette = NULL,
 
 # The palette based on flat design colors: https://www.materialui.co/flatuicolors
 flat_colors_list <- c(
-  `red` = "#e74c3c",
+  red = "#e74c3c",
   `dark red` = "#c0392b",
-  `purple` = "#9b59b6",
+  purple = "#9b59b6",
   `deep purple` = "#8e44ad",
-  `blue` = "#2980b9",
+  blue = "#2980b9",
   `light blue` = "#3498db",
-  `cyan` = "#1abc9c",
-  `teal` = "#16a085",
-  `green` = "#27ae60",
+  cyan = "#1abc9c",
+  teal = "#16a085",
+  green = "#27ae60",
   `light green` = "#2ecc71",
-  `yellow` = "#f1c40f",
-  `amber` = "#f39c12",
-  `orange` = "#e67e22",
+  yellow = "#f1c40f",
+  amber = "#f39c12",
+  orange = "#e67e22",
   `deep orange` = "#d35400",
-  `grey` = "#95a5a6",
+  grey = "#95a5a6",
   `blue grey` = "#7f8c8d"
 )
 
@@ -212,9 +212,9 @@ flat_colors <- function(...) {
 
 
 flat_palettes <- list(
-  `full` = flat_colors(),
-  `ice` = flat_colors("purple", "deep purple", "blue", "light blue"),
-  `rainbow` = flat_colors(
+  full = flat_colors(),
+  ice = flat_colors("purple", "deep purple", "blue", "light blue"),
+  rainbow = flat_colors(
     "purple",
     "deep purple",
     "blue",
@@ -226,9 +226,9 @@ flat_palettes <- list(
     "deep orange",
     "red"
   ),
-  `contrast` = flat_colors("blue", "green", "amber", "purple", "red"),
-  `light` = flat_colors("light blue", "purple", "yellow", "light green", "orange"),
-  `complement` = flat_colors(
+  contrast = flat_colors("blue", "green", "amber", "purple", "red"),
+  light = flat_colors("light blue", "purple", "yellow", "light green", "orange"),
+  complement = flat_colors(
     "blue grey",
     "blue",
     "light blue",

--- a/R/scale_color_flat.R
+++ b/R/scale_color_flat.R
@@ -1,8 +1,8 @@
 #' Flat UI color palette
 #'
-#' The palette based on [Flat UI](https://materialui.co/flatuicolors).
-#' Use `scale_color_flat_d` for *discrete* categories and
-#' `scale_color_flat_c` for a *continuous* scale.
+#' The palette based on [Flat UI](https://materialui.co/flatuicolors). Use
+#' `scale_color_flat_d` for *discrete* categories and `scale_color_flat_c` for a
+#' *continuous* scale, or use the `discrete` argument in `scale_color_flat()`.
 #'
 #' @inheritParams palette_flat
 #' @param discrete Boolean indicating whether color aesthetic is discrete or not.
@@ -18,23 +18,31 @@
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_boxplot() +
 #'   theme_modern() +
-#'   scale_fill_flat_d()
+#'   scale_fill_flat()
 #'
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_violin() +
 #'   theme_modern() +
-#'   scale_fill_flat_d(palette = "ice")
+#'   scale_fill_flat(palette = "ice")
 #'
 #' ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
 #'   geom_point() +
 #'   theme_modern() +
-#'   scale_color_flat_c(palette = "rainbow")
+#'   scale_color_flat(discrete = FALSE)
 #' @export
-scale_color_flat <- function(palette = "contrast",
+scale_color_flat <- function(palette = NULL,
                              discrete = TRUE,
                              reverse = FALSE,
                              aesthetics = "color",
                              ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_flat(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -50,7 +58,7 @@ scale_color_flat <- function(palette = "contrast",
 
 #' @rdname scale_color_flat
 #' @export
-scale_color_flat_d <- function(palette = "contrast",
+scale_color_flat_d <- function(palette = NULL,
                                discrete = TRUE,
                                reverse = FALSE,
                                aesthetics = "color",
@@ -66,7 +74,7 @@ scale_color_flat_d <- function(palette = "contrast",
 
 #' @rdname scale_color_flat
 #' @export
-scale_color_flat_c <- function(palette = "contrast",
+scale_color_flat_c <- function(palette = NULL,
                                discrete = FALSE,
                                reverse = FALSE,
                                aesthetics = "color",
@@ -98,11 +106,19 @@ scale_colour_flat_d <- scale_color_flat_d
 
 #' @rdname scale_color_flat
 #' @export
-scale_fill_flat <- function(palette = "contrast",
+scale_fill_flat <- function(palette = NULL,
                             discrete = TRUE,
                             reverse = FALSE,
                             aesthetics = "fill",
                             ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_flat(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -115,7 +131,7 @@ scale_fill_flat <- function(palette = "contrast",
 
 #' @rdname scale_color_flat
 #' @export
-scale_fill_flat_d <- function(palette = "contrast",
+scale_fill_flat_d <- function(palette = NULL,
                               discrete = TRUE,
                               reverse = FALSE,
                               aesthetics = "fill",
@@ -131,7 +147,7 @@ scale_fill_flat_d <- function(palette = "contrast",
 
 #' @rdname scale_color_flat
 #' @export
-scale_fill_flat_c <- function(palette = "contrast",
+scale_fill_flat_c <- function(palette = NULL,
                               discrete = FALSE,
                               reverse = FALSE,
                               aesthetics = "fill",
@@ -231,9 +247,13 @@ flat_palettes <- list(
 #' The palette based on [Flat UI](https://materialui.co/flatuicolors).
 #'
 #' @param palette Character name of palette. Depending on the color scale, can
-#'   be `"full"`, `"ice"`, `"rainbow"`, `"complement"`,
-#'   `"contrast"`, `"light"` (for dark themes), `"black_first"`, `full_original`,
-#'   or `black_first_original`.
+#' be one of `"full"`, `"ice"`, `"rainbow"`, `"complement"`, `"contrast"`,
+#' `"light"` (for dark themes), `"black_first"`, `full_original`, or
+#' `black_first_original`. The latter three options are especially for the
+#' Okabe-Ito color palette. The default is `NULL` and either `"contrast"` or
+#' `"complement"` is used (depending on whether `discrete` is `TRUE` or
+#' `FALSE`), which are the two scale useful for discrete or gradient color
+#' scales, respectively.
 #' @param reverse Boolean indicating whether the palette should be reversed.
 #' @param ... Additional arguments to pass to [`colorRampPalette()`][colorRampPalette].
 #'

--- a/R/scale_color_material.R
+++ b/R/scale_color_material.R
@@ -36,7 +36,7 @@ scale_color_material <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -112,7 +112,7 @@ scale_fill_material <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -214,6 +214,7 @@ material_colors <- function(...) {
 material_palettes <- list(
   full = material_colors(),
   ice = material_colors("purple", "deep purple", "indigo", "blue", "light blue"),
+  gradient = material_colors("blue", "orange"),
   rainbow = material_colors(
     "purple",
     "deep purple",

--- a/R/scale_color_material.R
+++ b/R/scale_color_material.R
@@ -1,9 +1,9 @@
 #' Material design color palette
 #'
-#' The palette based on [material design
-#' colors](https://materialui.co/). Use `scale_color_material_d()` for
-#' *discrete* categories and `scale_color_material_c()` for a *continuous*
-#' scale.
+#' The palette based on [material design colors](https://materialui.co/). Use
+#' `scale_color_material_d()` for *discrete* categories and
+#' `scale_color_material_c()` for a *continuous* scale, or use the `discrete`
+#' argument in `scale_color_material()`.
 #'
 #' @inheritParams palette_material
 #' @inheritParams scale_color_flat
@@ -15,23 +15,31 @@
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_boxplot() +
 #'   theme_modern() +
-#'   scale_fill_material_d()
+#'   scale_fill_material()
 #'
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_violin() +
 #'   theme_modern() +
-#'   scale_fill_material_d(palette = "ice")
+#'   scale_fill_material(palette = "ice")
 #'
 #' ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
 #'   geom_point() +
 #'   theme_modern() +
-#'   scale_color_material_c(palette = "rainbow")
+#'   scale_color_material(discrete = FALSE)
 #' @export
-scale_color_material <- function(palette = "contrast",
+scale_color_material <- function(palette = NULL,
                                  discrete = TRUE,
                                  reverse = FALSE,
                                  aesthetics = "color",
                                  ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_material(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -47,7 +55,7 @@ scale_color_material <- function(palette = "contrast",
 
 #' @rdname scale_color_material
 #' @export
-scale_color_material_d <- function(palette = "contrast",
+scale_color_material_d <- function(palette = NULL,
                                    discrete = TRUE,
                                    reverse = FALSE,
                                    aesthetics = "color",
@@ -95,11 +103,19 @@ scale_colour_material_d <- scale_color_material_d
 
 #' @rdname scale_color_material
 #' @export
-scale_fill_material <- function(palette = "contrast",
+scale_fill_material <- function(palette = NULL,
                                 discrete = TRUE,
                                 reverse = FALSE,
                                 aesthetics = "fill",
                                 ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_material(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -112,7 +128,7 @@ scale_fill_material <- function(palette = "contrast",
 
 #' @rdname scale_color_material
 #' @export
-scale_fill_material_d <- function(palette = "contrast",
+scale_fill_material_d <- function(palette = NULL,
                                   discrete = TRUE,
                                   reverse = FALSE,
                                   aesthetics = "fill",
@@ -128,7 +144,7 @@ scale_fill_material_d <- function(palette = "contrast",
 
 #' @rdname scale_color_material
 #' @export
-scale_fill_material_c <- function(palette = "contrast",
+scale_fill_material_c <- function(palette = NULL,
                                   discrete = FALSE,
                                   reverse = FALSE,
                                   aesthetics = "fill",

--- a/R/scale_color_material.R
+++ b/R/scale_color_material.R
@@ -164,24 +164,24 @@ scale_fill_material_c <- function(palette = NULL,
 
 # The palette based on material design colors: https://www.materialui.co/colors
 material_colors_list <- c(
-  `red` = "#f44336",
-  `pink` = "#E91E63",
-  `purple` = "#9C27B0",
+  red = "#f44336",
+  pink = "#E91E63",
+  purple = "#9C27B0",
   `deep purple` = "#673AB7",
-  `indigo` = "#3F51B5",
-  `blue` = "#2196F3",
+  indigo = "#3F51B5",
+  blue = "#2196F3",
   `light blue` = "#03A9F4",
-  `cyan` = "#00BCD4",
-  `teal` = "#009688",
-  `green` = "#4CAF50",
+  cyan = "#00BCD4",
+  teal = "#009688",
+  green = "#4CAF50",
   `light green` = "#8BC34A",
-  `lime` = "#CDDC39",
-  `yellow` = "#FFEB3B",
-  `amber` = "#FFC107",
-  `orange` = "#FF9800",
+  lime = "#CDDC39",
+  yellow = "#FFEB3B",
+  amber = "#FFC107",
+  orange = "#FF9800",
   `deep orange` = "#FF5722",
-  `brown` = "#795548",
-  `grey` = "#9E9E9E",
+  brown = "#795548",
+  grey = "#9E9E9E",
   `blue grey` = "#607D8B"
 )
 
@@ -212,9 +212,9 @@ material_colors <- function(...) {
 
 
 material_palettes <- list(
-  `full` = material_colors(),
-  `ice` = material_colors("purple", "deep purple", "indigo", "blue", "light blue"),
-  `rainbow` = material_colors(
+  full = material_colors(),
+  ice = material_colors("purple", "deep purple", "indigo", "blue", "light blue"),
+  rainbow = material_colors(
     "purple",
     "deep purple",
     "indigo",
@@ -229,9 +229,9 @@ material_palettes <- list(
     "red",
     "pink"
   ),
-  `contrast` = material_colors("blue", "green", "amber", "purple", "red"),
-  `light` = material_colors("light blue", "pink", "yellow", "light green", "orange"),
-  `complement` = material_colors(
+  contrast = material_colors("blue", "green", "amber", "purple", "red"),
+  light = material_colors("light blue", "pink", "yellow", "light green", "orange"),
+  complement = material_colors(
     "blue",
     "blue grey",
     "teal",

--- a/R/scale_color_metro.R
+++ b/R/scale_color_metro.R
@@ -36,7 +36,7 @@ scale_color_metro <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -112,7 +112,7 @@ scale_fill_metro <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -164,18 +164,18 @@ scale_fill_metro_c <- function(palette = NULL,
 
 # The palette based on metro design colors: https://www.materialui.co/metrocolors
 metro_colors_list <- c(
-  `red` = "#e51400",
+  red = "#e51400",
   `dark red` = "#a20025",
-  `purple` = "#aa00ff",
+  purple = "#aa00ff",
   `deep purple` = "#76608a",
-  `blue` = "#0050ef",
+  blue = "#0050ef",
   `light blue` = "#1ba1e2",
-  `teal` = "#00aba9",
-  `green` = "#008a00",
+  teal = "#00aba9",
+  green = "#008a00",
   `light green` = "#60a917",
-  `yellow` = "#e3c800",
-  `amber` = "#f0a30a",
-  `orange` = "#fa6800",
+  yellow = "#e3c800",
+  amber = "#f0a30a",
+  orange = "#fa6800",
   `deep orange` = "#a0522d",
   `blue grey` = "#647687"
 )
@@ -207,9 +207,10 @@ metro_colors <- function(...) {
 
 
 metro_palettes <- list(
-  `full` = metro_colors(),
-  `ice` = metro_colors("purple", "deep purple", "blue", "light blue"),
-  `rainbow` = metro_colors(
+  full = metro_colors(),
+  ice = metro_colors("purple", "deep purple", "blue", "light blue"),
+  gradient = metro_colors("blue", "orange"),
+  rainbow = metro_colors(
     "purple",
     "deep purple",
     "blue",
@@ -221,9 +222,9 @@ metro_palettes <- list(
     "deep orange",
     "red"
   ),
-  `contrast` = metro_colors("blue", "green", "amber", "purple", "red"),
-  `light` = material_colors("light blue", "red", "yellow", "light green", "orange"),
-  `complement` = metro_colors(
+  contrast = metro_colors("blue", "green", "amber", "purple", "red"),
+  light = material_colors("light blue", "red", "yellow", "light green", "orange"),
+  complement = metro_colors(
     "blue grey",
     "blue",
     "light blue",

--- a/R/scale_color_metro.R
+++ b/R/scale_color_metro.R
@@ -1,9 +1,9 @@
 #' Metro color palette
 #'
-#' The palette based on Metro [Metro
-#' colors](https://materialui.co/metrocolors).
-#' Use `scale_color_metro_d` for *discrete* categories and
-#' `scale_color_metro_c` for a *continuous* scale.
+#' The palette based on Metro [Metro colors](https://materialui.co/metrocolors).
+#' Use `scale_color_metro_d` for *discrete* categories and `scale_color_metro_c`
+#' for a *continuous* scale, or use the `discrete` argument in
+#' `scale_color_metro()`.
 #'
 #' @inheritParams palette_metro
 #' @inheritParams scale_color_flat
@@ -15,23 +15,31 @@
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_boxplot() +
 #'   theme_modern() +
-#'   scale_fill_metro_d()
+#'   scale_fill_metro()
 #'
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_violin() +
 #'   theme_modern() +
-#'   scale_fill_metro_d(palette = "ice")
+#'   scale_fill_metro(palette = "ice")
 #'
 #' ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
 #'   geom_point() +
 #'   theme_modern() +
-#'   scale_color_metro_c(palette = "rainbow")
+#'   scale_color_metro(discrete = FALSE)
 #' @export
-scale_color_metro <- function(palette = "complement",
+scale_color_metro <- function(palette = NULL,
                               discrete = TRUE,
                               reverse = FALSE,
                               aesthetics = "color",
                               ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_metro(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -47,7 +55,7 @@ scale_color_metro <- function(palette = "complement",
 
 #' @rdname scale_color_metro
 #' @export
-scale_color_metro_d <- function(palette = "complement",
+scale_color_metro_d <- function(palette = NULL,
                                 discrete = TRUE,
                                 reverse = FALSE,
                                 aesthetics = "color",
@@ -63,7 +71,7 @@ scale_color_metro_d <- function(palette = "complement",
 
 #' @rdname scale_color_metro
 #' @export
-scale_color_metro_c <- function(palette = "complement",
+scale_color_metro_c <- function(palette = NULL,
                                 discrete = FALSE,
                                 reverse = FALSE,
                                 aesthetics = "color",
@@ -95,11 +103,19 @@ scale_colour_metro_d <- scale_color_metro_d
 
 #' @rdname scale_color_metro
 #' @export
-scale_fill_metro <- function(palette = "complement",
+scale_fill_metro <- function(palette = NULL,
                              discrete = TRUE,
                              reverse = FALSE,
                              aesthetics = "fill",
                              ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_metro(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -112,7 +128,7 @@ scale_fill_metro <- function(palette = "complement",
 
 #' @rdname scale_color_metro
 #' @export
-scale_fill_metro_d <- function(palette = "complement",
+scale_fill_metro_d <- function(palette = NULL,
                                discrete = TRUE,
                                reverse = FALSE,
                                aesthetics = "fill",
@@ -128,7 +144,7 @@ scale_fill_metro_d <- function(palette = "complement",
 
 #' @rdname scale_color_metro
 #' @export
-scale_fill_metro_c <- function(palette = "complement",
+scale_fill_metro_c <- function(palette = NULL,
                                discrete = FALSE,
                                reverse = FALSE,
                                aesthetics = "fill",

--- a/R/scale_color_okabeito.R
+++ b/R/scale_color_okabeito.R
@@ -6,8 +6,9 @@
 #' includes 9 vivid colors that are readily nameable and include colors that
 #' correspond to major primary and secondary colors (e.g., red, yellow, blue).
 #'
-#' The Okabe-Ito palette is included in the base R [grDevices::palette.colors()].
-#' These functions make this palette easier to use with *ggplot2*.
+#' The Okabe-Ito palette is included in the base R
+#' [grDevices::palette.colors()]. These functions make this palette easier to
+#' use with *ggplot2*.
 #'
 #' The original Okabe-Ito palette's "yellow" color is `"#F0E442"`. This color is
 #' very bright and often does not show up well on white backgrounds (see
@@ -20,9 +21,9 @@
 #' the original yellow color suggested by Okabe and Ito (`"#F0E442"`), use
 #' palettes `"full_original"` or `"black_first_original"`.
 #'
-#' The Okabe-Ito palette is only available as a discrete palette.
-#' For color-accessible continuous variables, consider
-#' [the viridis palettes][ggplot2::scale_colour_viridis_d()].
+#' The Okabe-Ito palette is only available as a discrete palette. For
+#' color-accessible continuous variables, consider [the viridis
+#' palettes][ggplot2::scale_colour_viridis_d()].
 #'
 #' @inheritParams palette_okabeito
 #' @inheritParams scale_color_flat

--- a/R/scale_color_okabeito.R
+++ b/R/scale_color_okabeito.R
@@ -101,21 +101,21 @@ scale_fill_oi <- scale_fill_okabeito
 
 # The palette from: https://jfly.uni-koeln.de/color/#pallet
 okabeito_colors_list <- c(
-  `orange` = "#E69F00",
+  orange = "#E69F00",
   `light blue` = "#56B4E9",
-  `green` = "#009E73",
-  `yellow` = "#F0E442",
-  `blue` = "#0072B2",
-  `red` = "#D55E00",
-  `purple` = "#CC79A7",
-  `grey` = "#999999",
-  `black` = "#000000",
+  green = "#009E73",
+  yellow = "#F0E442",
+  blue = "#0072B2",
+  red = "#D55E00",
+  purple = "#CC79A7",
+  grey = "#999999",
+  black = "#000000",
   `sky blue` = "#56B4E9",
   `bluish green` = "#009E73",
-  `vermillion` = "#D55E00",
+  vermillion = "#D55E00",
   `reddish purple` = "#CC79A7",
   `dark yellow` = "#F5C710",
-  `amber` = "#F5C710"
+  amber = "#F5C710"
 )
 
 
@@ -170,10 +170,10 @@ okabeito_colors <- function(..., original_names = FALSE, black_first = FALSE, am
 oi_colors <- okabeito_colors
 
 okabeito_palettes <- list(
-  `full` = okabeito_colors(black_first = FALSE, amber = TRUE),
-  `black_first` = okabeito_colors(black_first = TRUE, amber = TRUE),
-  `full_original` = okabeito_colors(black_first = FALSE, amber = FALSE),
-  `black_original` = okabeito_colors(black_first = TRUE, amber = FALSE)
+  full = okabeito_colors(black_first = FALSE, amber = TRUE),
+  black_first = okabeito_colors(black_first = TRUE, amber = TRUE),
+  full_original = okabeito_colors(black_first = FALSE, amber = FALSE),
+  black_original = okabeito_colors(black_first = TRUE, amber = FALSE)
 )
 
 

--- a/R/scale_color_pizza.R
+++ b/R/scale_color_pizza.R
@@ -144,12 +144,12 @@ scale_fill_pizza_c <- function(palette = "margherita",
 # The palette based on this image:
 # https://www.scattidigusto.it/wp-content/uploads/2018/03/pizza-margherita-originale-Scatti-di-Gusto.jpg
 pizza_colors_list <- c(
-  `tomato` = "#CE3722",
-  `mozzarella` = "#EBE8E1",
-  `basil` = "#768947",
-  `crust` = "#E7CBA3",
-  `coal` = "#302124",
-  `diavola` = "#642118"
+  tomato = "#CE3722",
+  mozzarella = "#EBE8E1",
+  basil = "#768947",
+  crust = "#E7CBA3",
+  coal = "#302124",
+  diavola = "#642118"
 )
 
 
@@ -172,10 +172,11 @@ pizza_colors <- function(...) {
 
 
 pizza_palettes <- list(
-  `margherita` = pizza_colors("tomato", "mozzarella", "basil"),
-  `margherita_crust` = pizza_colors("crust", "tomato", "mozzarella", "basil", "coal"),
-  `diavola` = pizza_colors("tomato", "mozzarella", "basil", "diavola"),
-  `diavola_crust` = pizza_colors("crust", "tomato", "mozzarella", "basil", "diavola", "coal")
+  margherita = pizza_colors("tomato", "mozzarella", "basil"),
+  `margherita crust` = pizza_colors("crust", "tomato", "mozzarella", "basil", "coal"),
+  diavola = pizza_colors("tomato", "mozzarella", "basil", "diavola"),
+  `diavola crust` = pizza_colors("crust", "tomato", "mozzarella", "basil", "diavola", "coal"),
+  gradient = c("basil", "tomato")
 )
 
 
@@ -183,8 +184,8 @@ pizza_palettes <- list(
 #'
 #' The palette based on authentic neapolitan pizzas.
 #'
-#' @param palette Pizza type. Can be `"margherita"` (default), `"margherita_crust"`,
-#' `"diavola"` or `"diavola_crust"`.
+#' @param palette Pizza type. Can be `"margherita"` (default), `"margherita crust"`,
+#' `"diavola"` or `"diavola crust"`.
 #' @param reverse Boolean indicating whether the palette should be reversed.
 #' @param ... Additional arguments to pass to [`colorRampPalette()`][colorRampPalette].
 #'

--- a/R/scale_color_pizza.R
+++ b/R/scale_color_pizza.R
@@ -183,8 +183,8 @@ pizza_palettes <- list(
 #'
 #' The palette based on authentic neapolitan pizzas.
 #'
-#' @param palette Pizza type. Can be "margherita" (default), "margherita_crust",
-#'  "diavola" or "diavola_crust".
+#' @param palette Pizza type. Can be `"margherita"` (default), `"margherita_crust"`,
+#' `"diavola"` or `"diavola_crust"`.
 #' @param reverse Boolean indicating whether the palette should be reversed.
 #' @param ... Additional arguments to pass to [`colorRampPalette()`][colorRampPalette].
 #'

--- a/R/scale_color_see.R
+++ b/R/scale_color_see.R
@@ -1,7 +1,8 @@
 #' See color palette
 #'
-#' The See color palette. Use `scale_color_see_d()` for *discrete*
-#' categories and `scale_color_see_c()` for a *continuous* scale.
+#' The See color palette. Use `scale_color_see_d()` for *discrete* categories
+#' and `scale_color_see_c()` for a *continuous* scale, or use the `discrete`
+#' argument in `scale_color_see()`.
 #'
 #' @inheritParams palette_see
 #' @inheritParams scale_color_flat
@@ -13,7 +14,7 @@
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_boxplot() +
 #'   theme_modern() +
-#'   scale_fill_see_d()
+#'   scale_fill_see()
 #'
 #' ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, colour = Species)) +
 #'   geom_point() +
@@ -23,13 +24,20 @@
 #' ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
 #'   geom_point() +
 #'   theme_modern() +
-#'   scale_color_see_c(palette = "rainbow")
+#'   scale_color_see(discrete = FALSE)
 #' @export
-scale_color_see <- function(palette = "contrast",
+scale_color_see <- function(palette = NULL,
                             discrete = TRUE,
                             reverse = FALSE,
                             aesthetics = "color",
                             ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
   pal <- palette_see(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -45,7 +53,7 @@ scale_color_see <- function(palette = "contrast",
 
 #' @rdname scale_color_see
 #' @export
-scale_color_see_d <- function(palette = "contrast",
+scale_color_see_d <- function(palette = NULL,
                               discrete = TRUE,
                               reverse = FALSE,
                               aesthetics = "color",
@@ -61,7 +69,7 @@ scale_color_see_d <- function(palette = "contrast",
 
 #' @rdname scale_color_see
 #' @export
-scale_color_see_c <- function(palette = "contrast",
+scale_color_see_c <- function(palette = NULL,
                               discrete = FALSE,
                               reverse = FALSE,
                               aesthetics = "color",
@@ -93,11 +101,19 @@ scale_colour_see_d <- scale_color_see_d
 
 #' @rdname scale_color_see
 #' @export
-scale_fill_see <- function(palette = "contrast",
+scale_fill_see <- function(palette = NULL,
                            discrete = TRUE,
                            reverse = FALSE,
                            aesthetics = "fill",
                            ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_see(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -110,7 +126,7 @@ scale_fill_see <- function(palette = "contrast",
 
 #' @rdname scale_color_see
 #' @export
-scale_fill_see_d <- function(palette = "contrast",
+scale_fill_see_d <- function(palette = NULL,
                              discrete = TRUE,
                              reverse = FALSE,
                              aesthetics = "fill",
@@ -126,7 +142,7 @@ scale_fill_see_d <- function(palette = "contrast",
 
 #' @rdname scale_color_see
 #' @export
-scale_fill_see_c <- function(palette = "contrast",
+scale_fill_see_c <- function(palette = NULL,
                              discrete = FALSE,
                              reverse = FALSE,
                              aesthetics = "fill",

--- a/R/scale_color_see.R
+++ b/R/scale_color_see.R
@@ -35,7 +35,7 @@ scale_color_see <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
   pal <- palette_see(palette = palette, reverse = reverse)
@@ -110,7 +110,7 @@ scale_fill_see <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -206,9 +206,10 @@ see_colors <- function(...) {
 
 
 see_palettes <- list(
-  `full` = see_colors(),
-  `ice` = see_colors("indigo", "blue", "blue grey", "cyan", "light blue"),
-  `rainbow` = see_colors(
+  full = see_colors(),
+  ice = see_colors("indigo", "blue", "blue grey", "cyan", "light blue"),
+  gradient = see_colors("blue", "orange"),
+  rainbow = see_colors(
     "purple",
     "deep purple",
     "indigo",
@@ -222,8 +223,8 @@ see_palettes <- list(
     "red",
     "pink"
   ),
-  `contrast` = see_colors("blue", "orange", "yellow", "green", "red"),
-  `complement` = see_colors(
+  contrast = see_colors("blue", "orange", "yellow", "green", "red"),
+  complement = see_colors(
     "blue",
     "blue grey",
     "green",
@@ -232,7 +233,7 @@ see_palettes <- list(
     "amber",
     "red"
   ),
-  `light` = see_colors("light blue", "pink", "lime", "light green", "orange")
+  light = see_colors("light blue", "pink", "lime", "light green", "orange")
 )
 
 

--- a/R/scale_color_see.R
+++ b/R/scale_color_see.R
@@ -161,21 +161,21 @@ scale_fill_see_c <- function(palette = NULL,
 
 
 see_colors_list <- c(
-  `red` = "#d32626",
-  `pink` = "#b5076b",
-  `purple` = "#5c2a9d",
+  red = "#d32626",
+  pink = "#b5076b",
+  purple = "#5c2a9d",
   `deep purple` = "#45046a",
-  `indigo` = "#303960",
-  `blue` = "#1b6ca8",
+  indigo = "#303960",
+  blue = "#1b6ca8",
   `light blue` = "#03A9F4",
-  `cyan` = "#0a97b0",
-  `green` = "#438a5e",
+  cyan = "#0a97b0",
+  green = "#438a5e",
   `light green` = "#bac964",
-  `lime` = "#f7fbe1",
-  `yellow` = "#fbd46d",
-  `amber` = "#ff9c71",
-  `orange` = "#fb7813",
-  `grey` = "#e7dfd5",
+  lime = "#f7fbe1",
+  yellow = "#fbd46d",
+  amber = "#ff9c71",
+  orange = "#fb7813",
+  grey = "#e7dfd5",
   `blue grey` = "#3b6978"
 )
 

--- a/R/scale_color_social.R
+++ b/R/scale_color_social.R
@@ -1,8 +1,9 @@
 #' Social color palette
 #'
-#' The palette based [Social colors](https://materialui.co/socialcolors).
-#' Use `scale_color_social_d` for *discrete* categories and
-#' `scale_color_social_c` for a *continuous* scale.
+#' The palette based [Social colors](https://materialui.co/socialcolors). Use
+#' `scale_color_social_d` for *discrete* categories and `scale_color_social_c`
+#' for a *continuous* scale, or use the `discrete` argument in
+#' `scale_color_social()`.
 #'
 #' @inheritParams palette_social
 #' @inheritParams scale_color_flat
@@ -14,19 +15,31 @@
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_boxplot() +
 #'   theme_modern() +
-#'   scale_fill_social_d()
+#'   scale_fill_social()
 #'
 #' ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
 #'   geom_violin() +
 #'   theme_modern() +
-#'   scale_fill_social_d(palette = "ice")
+#'   scale_fill_social(palette = "ice")
 #'
 #' ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
 #'   geom_point() +
 #'   theme_modern() +
-#'   scale_color_social_c(palette = "rainbow")
+#'   scale_color_social(discrete = FALSE)
 #' @export
-scale_color_social <- function(palette = "complement", discrete = TRUE, reverse = FALSE, aesthetics = "color", ...) {
+scale_color_social <- function(palette = NULL,
+                               discrete = TRUE,
+                               reverse = FALSE,
+                               aesthetics = "color",
+                               ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_social(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -42,13 +55,13 @@ scale_color_social <- function(palette = "complement", discrete = TRUE, reverse 
 
 #' @rdname scale_color_social
 #' @export
-scale_color_social_d <- function(palette = "complement", discrete = TRUE, reverse = FALSE, aesthetics = "color", ...) {
+scale_color_social_d <- function(palette = NULL, discrete = TRUE, reverse = FALSE, aesthetics = "color", ...) {
   scale_color_social(palette = palette, discrete = discrete, reverse = reverse, aesthetics = aesthetics, ...)
 }
 
 #' @rdname scale_color_social
 #' @export
-scale_color_social_c <- function(palette = "complement", discrete = FALSE, reverse = FALSE, aesthetics = "color", ...) {
+scale_color_social_c <- function(palette = NULL, discrete = FALSE, reverse = FALSE, aesthetics = "color", ...) {
   scale_color_social(palette = palette, discrete = discrete, reverse = reverse, aesthetics = aesthetics, ...)
 }
 
@@ -70,7 +83,15 @@ scale_colour_social_d <- scale_color_social_d
 
 #' @rdname scale_color_social
 #' @export
-scale_fill_social <- function(palette = "complement", discrete = TRUE, reverse = FALSE, aesthetics = "fill", ...) {
+scale_fill_social <- function(palette = NULL, discrete = TRUE, reverse = FALSE, aesthetics = "fill", ...) {
+  if (is.null(palette)) {
+    if (discrete) {
+      palette <- "contrast"
+    } else {
+      palette <- "complement"
+    }
+  }
+
   pal <- palette_social(palette = palette, reverse = reverse)
 
   if (discrete) {
@@ -83,13 +104,13 @@ scale_fill_social <- function(palette = "complement", discrete = TRUE, reverse =
 
 #' @rdname scale_color_social
 #' @export
-scale_fill_social_d <- function(palette = "complement", discrete = TRUE, reverse = FALSE, aesthetics = "fill", ...) {
+scale_fill_social_d <- function(palette = NULL, discrete = TRUE, reverse = FALSE, aesthetics = "fill", ...) {
   scale_fill_social(palette = palette, discrete = discrete, reverse = reverse, aesthetics = aesthetics, ...)
 }
 
 #' @rdname scale_color_social
 #' @export
-scale_fill_social_c <- function(palette = "complement", discrete = FALSE, reverse = FALSE, aesthetics = "fill", ...) {
+scale_fill_social_c <- function(palette = NULL, discrete = FALSE, reverse = FALSE, aesthetics = "fill", ...) {
   scale_fill_social(palette = palette, discrete = discrete, reverse = reverse, aesthetics = aesthetics, ...)
 }
 

--- a/R/scale_color_social.R
+++ b/R/scale_color_social.R
@@ -36,7 +36,7 @@ scale_color_social <- function(palette = NULL,
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -88,7 +88,7 @@ scale_fill_social <- function(palette = NULL, discrete = TRUE, reverse = FALSE, 
     if (discrete) {
       palette <- "contrast"
     } else {
-      palette <- "complement"
+      palette <- "gradient"
     }
   }
 
@@ -165,9 +165,10 @@ social_colors <- function(...) {
 
 
 social_palettes <- list(
-  `full` = social_colors(),
-  `ice` = social_colors("purple", "deep purple", "blue", "light blue"),
-  `rainbow` = social_colors(
+  full = social_colors(),
+  ice = social_colors("purple", "deep purple", "blue", "light blue"),
+  gradient = social_colors("blue", "orange"),
+  rainbow = social_colors(
     "purple",
     "deep purple",
     "blue",
@@ -179,9 +180,9 @@ social_palettes <- list(
     "deep orange",
     "red"
   ),
-  `contrast` = social_colors("blue", "green", "amber", "purple", "red"),
-  `light` = material_colors("light blue", "purple", "yellow", "light green", "deep orange"),
-  `complement` = social_colors(
+  contrast = social_colors("blue", "green", "amber", "purple", "red"),
+  light = material_colors("light blue", "purple", "yellow", "light green", "deep orange"),
+  complement = social_colors(
     "blue grey",
     "blue",
     "light blue",

--- a/R/scale_color_social.R
+++ b/R/scale_color_social.R
@@ -120,21 +120,21 @@ scale_fill_social_c <- function(palette = NULL, discrete = FALSE, reverse = FALS
 
 # The palette based on flat design colors: https://www.materialui.co/socialcolors
 social_colors_list <- c(
-  `red` = "#cd201f",
+  red = "#cd201f",
   `dark red` = "#b92b27",
-  `purple` = "#ea4c89",
+  purple = "#ea4c89",
   `deep purple` = "#410093",
-  `blue` = "#0077B5",
+  blue = "#0077B5",
   `light blue` = "#55acee",
-  `cyan` = "#1ab7ea",
-  `teal` = "#00b489",
-  `green` = "#3aaf85",
+  cyan = "#1ab7ea",
+  teal = "#00b489",
+  green = "#3aaf85",
   `light green` = "#25D366",
-  `yellow` = "#FFFC00",
-  `amber` = "#f57d00",
-  `orange` = "#ff6600",
+  yellow = "#FFFC00",
+  amber = "#f57d00",
+  orange = "#ff6600",
   `deep orange` = "#ff3300",
-  `grey` = "#34465d",
+  grey = "#34465d",
   `blue grey` = "#21759b"
 )
 

--- a/man/palette_bluebrown.Rd
+++ b/man/palette_bluebrown.Rd
@@ -8,9 +8,13 @@ palette_bluebrown(palette = "contrast", reverse = FALSE, ...)
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_bluebrown.Rd
+++ b/man/palette_bluebrown.Rd
@@ -12,9 +12,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_flat.Rd
+++ b/man/palette_flat.Rd
@@ -8,9 +8,13 @@ palette_flat(palette = "contrast", reverse = FALSE, ...)
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_flat.Rd
+++ b/man/palette_flat.Rd
@@ -12,9 +12,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_material.Rd
+++ b/man/palette_material.Rd
@@ -8,9 +8,13 @@ palette_material(palette = "contrast", reverse = FALSE, ...)
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_material.Rd
+++ b/man/palette_material.Rd
@@ -12,9 +12,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_metro.Rd
+++ b/man/palette_metro.Rd
@@ -8,9 +8,13 @@ palette_metro(palette = "complement", reverse = FALSE, ...)
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_metro.Rd
+++ b/man/palette_metro.Rd
@@ -12,9 +12,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_okabeito.Rd
+++ b/man/palette_okabeito.Rd
@@ -15,9 +15,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_okabeito.Rd
+++ b/man/palette_okabeito.Rd
@@ -11,9 +11,13 @@ palette_oi(palette = "full_amber", reverse = FALSE, order = 1:9, ...)
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_pizza.Rd
+++ b/man/palette_pizza.Rd
@@ -7,8 +7,8 @@
 palette_pizza(palette = "margherita", reverse = FALSE, ...)
 }
 \arguments{
-\item{palette}{Pizza type. Can be \code{"margherita"} (default), \code{"margherita_crust"},
-\code{"diavola"} or \code{"diavola_crust"}.}
+\item{palette}{Pizza type. Can be \code{"margherita"} (default), \code{"margherita crust"},
+\code{"diavola"} or \code{"diavola crust"}.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_pizza.Rd
+++ b/man/palette_pizza.Rd
@@ -7,8 +7,8 @@
 palette_pizza(palette = "margherita", reverse = FALSE, ...)
 }
 \arguments{
-\item{palette}{Pizza type. Can be "margherita" (default), "margherita_crust",
-"diavola" or "diavola_crust".}
+\item{palette}{Pizza type. Can be \code{"margherita"} (default), \code{"margherita_crust"},
+\code{"diavola"} or \code{"diavola_crust"}.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_see.Rd
+++ b/man/palette_see.Rd
@@ -8,9 +8,13 @@ palette_see(palette = "contrast", reverse = FALSE, ...)
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_see.Rd
+++ b/man/palette_see.Rd
@@ -12,9 +12,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_social.Rd
+++ b/man/palette_social.Rd
@@ -8,9 +8,13 @@ palette_social(palette = "complement", reverse = FALSE, ...)
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/palette_social.Rd
+++ b/man/palette_social.Rd
@@ -12,9 +12,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/scale_color_bluebrown.Rd
+++ b/man/scale_color_bluebrown.Rd
@@ -13,7 +13,7 @@
 \title{Blue-brown color palette}
 \usage{
 scale_color_bluebrown(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -21,7 +21,7 @@ scale_color_bluebrown(
 )
 
 scale_color_bluebrown_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -29,7 +29,7 @@ scale_color_bluebrown_d(
 )
 
 scale_color_bluebrown_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -37,7 +37,7 @@ scale_color_bluebrown_c(
 )
 
 scale_colour_bluebrown(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -45,7 +45,7 @@ scale_colour_bluebrown(
 )
 
 scale_colour_bluebrown_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -53,7 +53,7 @@ scale_colour_bluebrown_c(
 )
 
 scale_colour_bluebrown_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -61,7 +61,7 @@ scale_colour_bluebrown_d(
 )
 
 scale_fill_bluebrown(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -69,7 +69,7 @@ scale_fill_bluebrown(
 )
 
 scale_fill_bluebrown_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -77,7 +77,7 @@ scale_fill_bluebrown_d(
 )
 
 scale_fill_bluebrown_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -86,9 +86,13 @@ scale_fill_bluebrown_c(
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_bluebrown.Rd
+++ b/man/scale_color_bluebrown.Rd
@@ -90,9 +90,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_flat.Rd
+++ b/man/scale_color_flat.Rd
@@ -13,7 +13,7 @@
 \title{Flat UI color palette}
 \usage{
 scale_color_flat(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -21,7 +21,7 @@ scale_color_flat(
 )
 
 scale_color_flat_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -29,7 +29,7 @@ scale_color_flat_d(
 )
 
 scale_color_flat_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -37,7 +37,7 @@ scale_color_flat_c(
 )
 
 scale_colour_flat(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -45,7 +45,7 @@ scale_colour_flat(
 )
 
 scale_colour_flat_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -53,7 +53,7 @@ scale_colour_flat_c(
 )
 
 scale_colour_flat_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -61,7 +61,7 @@ scale_colour_flat_d(
 )
 
 scale_fill_flat(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -69,7 +69,7 @@ scale_fill_flat(
 )
 
 scale_fill_flat_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -77,7 +77,7 @@ scale_fill_flat_d(
 )
 
 scale_fill_flat_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -86,9 +86,13 @@ scale_fill_flat_c(
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 
@@ -101,9 +105,9 @@ should be applied to (e.g., \code{c('color', 'fill')}).}
 is \code{TRUE} or to \code{scale_color_gradientn()} when \code{discrete} is \code{FALSE}.}
 }
 \description{
-The palette based on \href{https://materialui.co/flatuicolors}{Flat UI}.
-Use \code{scale_color_flat_d} for \emph{discrete} categories and
-\code{scale_color_flat_c} for a \emph{continuous} scale.
+The palette based on \href{https://materialui.co/flatuicolors}{Flat UI}. Use
+\code{scale_color_flat_d} for \emph{discrete} categories and \code{scale_color_flat_c} for a
+\emph{continuous} scale, or use the \code{discrete} argument in \code{scale_color_flat()}.
 }
 \examples{
 library(ggplot2)
@@ -112,15 +116,15 @@ library(see)
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_boxplot() +
   theme_modern() +
-  scale_fill_flat_d()
+  scale_fill_flat()
 
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_violin() +
   theme_modern() +
-  scale_fill_flat_d(palette = "ice")
+  scale_fill_flat(palette = "ice")
 
 ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
   geom_point() +
   theme_modern() +
-  scale_color_flat_c(palette = "rainbow")
+  scale_color_flat(discrete = FALSE)
 }

--- a/man/scale_color_flat.Rd
+++ b/man/scale_color_flat.Rd
@@ -90,9 +90,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_material.Rd
+++ b/man/scale_color_material.Rd
@@ -13,7 +13,7 @@
 \title{Material design color palette}
 \usage{
 scale_color_material(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -21,7 +21,7 @@ scale_color_material(
 )
 
 scale_color_material_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -37,7 +37,7 @@ scale_color_material_c(
 )
 
 scale_colour_material(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -53,7 +53,7 @@ scale_colour_material_c(
 )
 
 scale_colour_material_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -61,7 +61,7 @@ scale_colour_material_d(
 )
 
 scale_fill_material(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -69,7 +69,7 @@ scale_fill_material(
 )
 
 scale_fill_material_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -77,7 +77,7 @@ scale_fill_material_d(
 )
 
 scale_fill_material_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -86,9 +86,13 @@ scale_fill_material_c(
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 
@@ -100,9 +104,10 @@ should be applied to (e.g., \code{c('color', 'fill')}).}
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The palette based on \href{https://materialui.co/}{material design colors}. Use \code{scale_color_material_d()} for
-\emph{discrete} categories and \code{scale_color_material_c()} for a \emph{continuous}
-scale.
+The palette based on \href{https://materialui.co/}{material design colors}. Use
+\code{scale_color_material_d()} for \emph{discrete} categories and
+\code{scale_color_material_c()} for a \emph{continuous} scale, or use the \code{discrete}
+argument in \code{scale_color_material()}.
 }
 \examples{
 library(ggplot2)
@@ -111,15 +116,15 @@ library(see)
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_boxplot() +
   theme_modern() +
-  scale_fill_material_d()
+  scale_fill_material()
 
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_violin() +
   theme_modern() +
-  scale_fill_material_d(palette = "ice")
+  scale_fill_material(palette = "ice")
 
 ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
   geom_point() +
   theme_modern() +
-  scale_color_material_c(palette = "rainbow")
+  scale_color_material(discrete = FALSE)
 }

--- a/man/scale_color_material.Rd
+++ b/man/scale_color_material.Rd
@@ -90,9 +90,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_metro.Rd
+++ b/man/scale_color_metro.Rd
@@ -90,9 +90,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_metro.Rd
+++ b/man/scale_color_metro.Rd
@@ -13,7 +13,7 @@
 \title{Metro color palette}
 \usage{
 scale_color_metro(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -21,7 +21,7 @@ scale_color_metro(
 )
 
 scale_color_metro_d(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -29,7 +29,7 @@ scale_color_metro_d(
 )
 
 scale_color_metro_c(
-  palette = "complement",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -37,7 +37,7 @@ scale_color_metro_c(
 )
 
 scale_colour_metro(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -45,7 +45,7 @@ scale_colour_metro(
 )
 
 scale_colour_metro_c(
-  palette = "complement",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -53,7 +53,7 @@ scale_colour_metro_c(
 )
 
 scale_colour_metro_d(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -61,7 +61,7 @@ scale_colour_metro_d(
 )
 
 scale_fill_metro(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -69,7 +69,7 @@ scale_fill_metro(
 )
 
 scale_fill_metro_d(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -77,7 +77,7 @@ scale_fill_metro_d(
 )
 
 scale_fill_metro_c(
-  palette = "complement",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -86,9 +86,13 @@ scale_fill_metro_c(
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 
@@ -101,8 +105,9 @@ should be applied to (e.g., \code{c('color', 'fill')}).}
 }
 \description{
 The palette based on Metro \href{https://materialui.co/metrocolors}{Metro colors}.
-Use \code{scale_color_metro_d} for \emph{discrete} categories and
-\code{scale_color_metro_c} for a \emph{continuous} scale.
+Use \code{scale_color_metro_d} for \emph{discrete} categories and \code{scale_color_metro_c}
+for a \emph{continuous} scale, or use the \code{discrete} argument in
+\code{scale_color_metro()}.
 }
 \examples{
 library(ggplot2)
@@ -111,15 +116,15 @@ library(see)
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_boxplot() +
   theme_modern() +
-  scale_fill_metro_d()
+  scale_fill_metro()
 
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_violin() +
   theme_modern() +
-  scale_fill_metro_d(palette = "ice")
+  scale_fill_metro(palette = "ice")
 
 ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
   geom_point() +
   theme_modern() +
-  scale_color_metro_c(palette = "rainbow")
+  scale_color_metro(discrete = FALSE)
 }

--- a/man/scale_color_okabeito.Rd
+++ b/man/scale_color_okabeito.Rd
@@ -63,9 +63,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 

--- a/man/scale_color_okabeito.Rd
+++ b/man/scale_color_okabeito.Rd
@@ -59,9 +59,13 @@ scale_fill_oi(
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.}
 
@@ -81,8 +85,9 @@ includes 9 vivid colors that are readily nameable and include colors that
 correspond to major primary and secondary colors (e.g., red, yellow, blue).
 }
 \details{
-The Okabe-Ito palette is included in the base R \code{\link[grDevices:palette]{grDevices::palette.colors()}}.
-These functions make this palette easier to use with \emph{ggplot2}.
+The Okabe-Ito palette is included in the base R
+\code{\link[grDevices:palette]{grDevices::palette.colors()}}. These functions make this palette easier to
+use with \emph{ggplot2}.
 
 The original Okabe-Ito palette's "yellow" color is \code{"#F0E442"}. This color is
 very bright and often does not show up well on white backgrounds (see
@@ -94,9 +99,8 @@ The palettes \code{"full"} and \code{"black_first"} use this darker yellow color
 the original yellow color suggested by Okabe and Ito (\code{"#F0E442"}), use
 palettes \code{"full_original"} or \code{"black_first_original"}.
 
-The Okabe-Ito palette is only available as a discrete palette.
-For color-accessible continuous variables, consider
-\link[ggplot2:scale_viridis]{the viridis palettes}.
+The Okabe-Ito palette is only available as a discrete palette. For
+color-accessible continuous variables, consider \link[ggplot2:scale_viridis]{the viridis palettes}.
 }
 \examples{
 library(ggplot2)

--- a/man/scale_color_pizza.Rd
+++ b/man/scale_color_pizza.Rd
@@ -85,8 +85,8 @@ scale_fill_pizza_c(
 )
 }
 \arguments{
-\item{palette}{Pizza type. Can be \code{"margherita"} (default), \code{"margherita_crust"},
-\code{"diavola"} or \code{"diavola_crust"}.}
+\item{palette}{Pizza type. Can be \code{"margherita"} (default), \code{"margherita crust"},
+\code{"diavola"} or \code{"diavola crust"}.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_pizza.Rd
+++ b/man/scale_color_pizza.Rd
@@ -85,8 +85,8 @@ scale_fill_pizza_c(
 )
 }
 \arguments{
-\item{palette}{Pizza type. Can be "margherita" (default), "margherita_crust",
-"diavola" or "diavola_crust".}
+\item{palette}{Pizza type. Can be \code{"margherita"} (default), \code{"margherita_crust"},
+\code{"diavola"} or \code{"diavola_crust"}.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_see.Rd
+++ b/man/scale_color_see.Rd
@@ -13,7 +13,7 @@
 \title{See color palette}
 \usage{
 scale_color_see(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -21,7 +21,7 @@ scale_color_see(
 )
 
 scale_color_see_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -29,7 +29,7 @@ scale_color_see_d(
 )
 
 scale_color_see_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -37,7 +37,7 @@ scale_color_see_c(
 )
 
 scale_colour_see(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -45,7 +45,7 @@ scale_colour_see(
 )
 
 scale_colour_see_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -53,7 +53,7 @@ scale_colour_see_c(
 )
 
 scale_colour_see_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -61,7 +61,7 @@ scale_colour_see_d(
 )
 
 scale_fill_see(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -69,7 +69,7 @@ scale_fill_see(
 )
 
 scale_fill_see_d(
-  palette = "contrast",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -77,7 +77,7 @@ scale_fill_see_d(
 )
 
 scale_fill_see_c(
-  palette = "contrast",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -86,9 +86,13 @@ scale_fill_see_c(
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 
@@ -100,8 +104,9 @@ should be applied to (e.g., \code{c('color', 'fill')}).}
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The See color palette. Use \code{scale_color_see_d()} for \emph{discrete}
-categories and \code{scale_color_see_c()} for a \emph{continuous} scale.
+The See color palette. Use \code{scale_color_see_d()} for \emph{discrete} categories
+and \code{scale_color_see_c()} for a \emph{continuous} scale, or use the \code{discrete}
+argument in \code{scale_color_see()}.
 }
 \examples{
 library(ggplot2)
@@ -110,7 +115,7 @@ library(see)
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_boxplot() +
   theme_modern() +
-  scale_fill_see_d()
+  scale_fill_see()
 
 ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, colour = Species)) +
   geom_point() +
@@ -120,5 +125,5 @@ ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, colour = Species)) +
 ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
   geom_point() +
   theme_modern() +
-  scale_color_see_c(palette = "rainbow")
+  scale_color_see(discrete = FALSE)
 }

--- a/man/scale_color_see.Rd
+++ b/man/scale_color_see.Rd
@@ -90,9 +90,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 

--- a/man/scale_color_social.Rd
+++ b/man/scale_color_social.Rd
@@ -13,7 +13,7 @@
 \title{Social color palette}
 \usage{
 scale_color_social(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -21,7 +21,7 @@ scale_color_social(
 )
 
 scale_color_social_d(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -29,7 +29,7 @@ scale_color_social_d(
 )
 
 scale_color_social_c(
-  palette = "complement",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -37,7 +37,7 @@ scale_color_social_c(
 )
 
 scale_colour_social(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -45,7 +45,7 @@ scale_colour_social(
 )
 
 scale_colour_social_c(
-  palette = "complement",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "color",
@@ -53,7 +53,7 @@ scale_colour_social_c(
 )
 
 scale_colour_social_d(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "color",
@@ -61,7 +61,7 @@ scale_colour_social_d(
 )
 
 scale_fill_social(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -69,7 +69,7 @@ scale_fill_social(
 )
 
 scale_fill_social_d(
-  palette = "complement",
+  palette = NULL,
   discrete = TRUE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -77,7 +77,7 @@ scale_fill_social_d(
 )
 
 scale_fill_social_c(
-  palette = "complement",
+  palette = NULL,
   discrete = FALSE,
   reverse = FALSE,
   aesthetics = "fill",
@@ -86,9 +86,13 @@ scale_fill_social_c(
 }
 \arguments{
 \item{palette}{Character name of palette. Depending on the color scale, can
-be \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"},
-\code{"contrast"}, \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original},
-or \code{black_first_original}.}
+be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \code{"contrast"},
+\code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
+\code{black_first_original}. The latter three options are especially for the
+Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
+\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
+\code{FALSE}), which are the two scale useful for discrete or gradient color
+scales, respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 
@@ -100,9 +104,10 @@ should be applied to (e.g., \code{c('color', 'fill')}).}
 \item{...}{Additional arguments to pass to \code{\link[=colorRampPalette]{colorRampPalette()}}.}
 }
 \description{
-The palette based \href{https://materialui.co/socialcolors}{Social colors}.
-Use \code{scale_color_social_d} for \emph{discrete} categories and
-\code{scale_color_social_c} for a \emph{continuous} scale.
+The palette based \href{https://materialui.co/socialcolors}{Social colors}. Use
+\code{scale_color_social_d} for \emph{discrete} categories and \code{scale_color_social_c}
+for a \emph{continuous} scale, or use the \code{discrete} argument in
+\code{scale_color_social()}.
 }
 \examples{
 library(ggplot2)
@@ -111,15 +116,15 @@ library(see)
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_boxplot() +
   theme_modern() +
-  scale_fill_social_d()
+  scale_fill_social()
 
 ggplot(iris, aes(x = Species, y = Sepal.Length, fill = Species)) +
   geom_violin() +
   theme_modern() +
-  scale_fill_social_d(palette = "ice")
+  scale_fill_social(palette = "ice")
 
 ggplot(iris, aes(x = Petal.Length, y = Petal.Width, color = Sepal.Length)) +
   geom_point() +
   theme_modern() +
-  scale_color_social_c(palette = "rainbow")
+  scale_color_social(discrete = FALSE)
 }

--- a/man/scale_color_social.Rd
+++ b/man/scale_color_social.Rd
@@ -90,9 +90,9 @@ be one of \code{"full"}, \code{"ice"}, \code{"rainbow"}, \code{"complement"}, \c
 \code{"light"} (for dark themes), \code{"black_first"}, \code{full_original}, or
 \code{black_first_original}. The latter three options are especially for the
 Okabe-Ito color palette. The default is \code{NULL} and either \code{"contrast"} or
-\code{"complement"} is used (depending on whether \code{discrete} is \code{TRUE} or
-\code{FALSE}), which are the two scale useful for discrete or gradient color
-scales, respectively.}
+\code{"gradient"} is used (depending on whether \code{discrete} is \code{TRUE} or \code{FALSE}),
+which are the two scale useful for discrete or gradient color scales,
+respectively.}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete or not.}
 


### PR DESCRIPTION
The current default palettes for discrete look good, but the same palette, which was used as default for continuous (gradient) scales, looked not so good. This PR selects the better fitting `"complement"` palette automatically for non-discrete color scales. Here's a comparison:

``` r
library(ggplot2)
library(see)
```

# Metro colors 

## former default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_metro(palette = "contrast", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/u9Sg5je.png)<!-- -->

## new default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_metro(palette = "complement", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/z4H7xgo.png)<!-- -->

# See colors 

## former default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_see(palette = "contrast", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/Q0DycHb.png)<!-- -->

## new default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_see(palette = "complement", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/ItCcxNn.png)<!-- -->

# Flat colors 

## former default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_flat(palette = "contrast", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/zl6Er3K.png)<!-- -->

## new default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_flat(palette = "complement", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/jxOc8eo.png)<!-- -->

# Social colors 

## former default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_social(palette = "contrast", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/6Msq27S.png)<!-- -->

## new default gradient

``` r
ggplot(iris, aes(x = Sepal.Width, y = Sepal.Length, color = Petal.Width)) +
  geom_point() +
  scale_color_social(palette = "complement", discrete = FALSE) +
  theme_modern()
```

![](https://i.imgur.com/ZZJZ9kx.png)<!-- -->

<sup>Created on 2025-03-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
