### PR TITLE
`plot()` for `performance::check_normality()` now also supports objects from

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: see
 Title: Model Visualisation Toolbox for 'easystats' and 'ggplot2'
-Version: 0.11.0.3
+Version: 0.11.0.4
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
 * The minimum needed R version has been bumped to `4.1`, since `{correlation}`,
   a runtime dependency, requires it.
 
+## Changes
+
+* `plot()` for `performance::check_normality()` now also supports objects from
+  `psych::fa()`, `psych::principal()` and `parameters::factor_analysis()`.
+
 # see 0.11.0
 
 ## Changes
@@ -710,4 +715,3 @@
 ## Bug fixes
 
 * Fixed issues with color codes in the flat-ui palette.
-

--- a/R/plot.check_normality.R
+++ b/R/plot.check_normality.R
@@ -100,6 +100,9 @@ plot.see_check_normality <- function(
           (stats::ppoints(length(res_)) + 1) / 2
         )[order(order(res_))]
         dat <- stats::na.omit(data.frame(x = fitted_, y = res_))
+      } else if (inherits(model, c("fa", "principle", "parameters_efa"))) {
+        res_ <- abs(insight::get_residuals(model))
+        dat <- stats::na.omit(data.frame(y = res_))
       } else if (inherits(model, "performance_simres")) {
         return(plot.see_performance_simres(
           model,
@@ -141,6 +144,8 @@ plot.see_check_normality <- function(
         r <- r[!is.infinite(r)]
       } else if (is.numeric(model)) {
         r <- model[!is.infinite(model) & !is.na(model)]
+      } else if (inherits(model, c("fa", "principle", "parameters_efa"))) {
+        r <- insight::get_residuals(model)
       } else {
         r <- suppressMessages(stats::residuals(model))
       }
@@ -159,7 +164,11 @@ plot.see_check_normality <- function(
         size_title = size_title
       )
     } else if (type == "pp") {
-      x <- suppressMessages(sort(stats::residuals(model), na.last = NA))
+      if (inherits(model, c("fa", "principle", "parameters_efa"))) {
+        x <- sort(insight::get_residuals(model))
+      } else {
+        x <- suppressMessages(sort(stats::residuals(model), na.last = NA))
+      }
       dat <- data.frame(res = x)
       .plot_diag_pp(
         dat,


### PR DESCRIPTION
...`psych::fa()`, `psych::principal()` and `parameters::factor_analysis()`

See https://github.com/easystats/performance/issues/793